### PR TITLE
Api update and integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ target/
 cover
 .eggs
 .venv*
+
+# Vagrant, if you were running integration tests
+.vagrant

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: python
 python:
 - '2.7'
 sudo: false
-install: pip install .
-script: python setup.py nosetests
+install: pip install tox
+script: tox
 deploy:
   provider: pypi
   user: jporten

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,15 @@
+Version 3.0:
+ - reworked API, again - this version is a lot clearer and more explicit about what it does
+ - fixed issues around images with multiple names
+ - added limited unit tests
+ - added integration tests
+
+Version 2.0.1:
+ - Changed owner of travis CI job
+
+Version 2.0:
+ - updated command line API - container and images modes are now separate
+ - better control of container cleanup
 
 Version 1.2:
  - Fix missing package definition

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -2,24 +2,33 @@
 
 ## Tox
 
-"tox" is configured to create a source distribution and run flake8 against the code. To invoke it:
+"tox" is configured to create a source distribution, run unit tests, and run flake8 against the
+code. To invoke it, make sure you have the "tox" Python library installed, and run:
 
     tox
 
 ## Integration tests
-This project contains some automated integration tests that are designed to be run against a real
-Docker instance. They do clean up after themselves, but they are potentially destructive and so
-should probably be run in a safe environment.
+This project contains some automated integration tests. They test functionality, but the main thing
+they're trying to verify are the interactions between docker-rotate, the docker-py library, and the
+Docker daemon. Thus they are designed to run against a real Docker Engine instance, rather than a
+mock.
 
-They test all functionality, but the main thing they're trying to verify are the interactions
-between docker-rotate, the docker-py library, and the Docker daemon. Thus they are run with
+They are designed to clean up after themselves, but that isn't foolproof, especially if execution
+is interrupted. They also assume that they're being run against a Docker Engine instance with no
+containers and no images. Thus, overall, it's a good idea to run them in an isolated environment
+that can be easily reset.
 
-### Running tests in Vagrant
+### Running integration tests in Vagrant
+... and that's where Vagrant comes in. [Vagrant](https://www.vagrantup.com/docs/) is a tool for
+managing virtual machines on a local system. The project contains a "Vagrantfile" which describes
+some virtual machines that can be used for testing, and a script to trigger the tests.
+
 To run the full suite of tests in Vagrant, make sure you have a working copy of Vagrant, then:
 
     ./run_vagrant_integration_tests.sh
 
-If the tests fail, they may have left a Vagrant VM running.
+If the tests fail, they will leave the Vagrant VMs running. If the tests succeed, they will tear
+down the test VMs, unless you pass the "--keep" argument when you run the tests.
 
 ### Running tests locally:
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -1,0 +1,32 @@
+# Information for developers
+
+## Tox
+
+"tox" is configured to create a source distribution and run flake8 against the code. To invoke it:
+
+    tox
+
+## Integration tests
+This project contains some automated integration tests that are designed to be run against a real
+Docker instance. They do clean up after themselves, but they are potentially destructive and so
+should probably be run in a safe environment.
+
+They test all functionality, but the main thing they're trying to verify are the interactions
+between docker-rotate, the docker-py library, and the Docker daemon. Thus they are run with
+
+### Running tests in Vagrant
+To run the full suite of tests in Vagrant, make sure you have a working copy of Vagrant, then:
+
+    ./run_vagrant_integration_tests.sh
+
+If the tests fail, they may have left a Vagrant VM running.
+
+### Running tests locally:
+
+To run the integration tests locally:
+
+    tox -e integration_tests
+
+To run the integration tests with a specific docker-py version:
+
+    DOCKER_PY_VERSION='==1.7.0' tox -e integration_tests

--- a/README.md
+++ b/README.md
@@ -1,25 +1,81 @@
-docker-rotate
-=============
+#  docker-rotate
 
-In a continuously deployed environment, old and unused docker images and containers accumulate and use up space.
-`docker-rotate` helps remove the K oldest images of each type and remove non-running containers.
+In a continuously deployed environment, old and unused docker images and containers accumulate and
+use up space. `docker-rotate` provides a way to remove that cruft based on a policy you specify.
 
 [![Build Status](https://travis-ci.org/locationlabs/docker-rotate.png)](https://travis-ci.org/locationlabs/docker-rotate)
 
-Usage:
+## The problem
 
-    # delete all but the three most recent images of each type
+On a system that is using Docker in a production environment, there are a number of different types
+of data that can accumulate over time. They are:
+ - old versions of images: if you pull a new version of an image in order to recreate a container,
+   the old version can stick around. Depending on how tags are managed in your environment, these
+   might have one or more tags, or they might be completely untagged. (For example, if you have
+   a image with just the "foo:latest" tag on your system and you run `docker pull foo:latest` to get
+   an updated version, the new image will have the "foo:latest" tag and the old image will remain,
+   but will now be nameless. If the old image had instead started with "foo:latest" and "foo:xyz",
+   it would now be called "foo:xyz")
+ - "exited" containers: If a container runs and halts for some reason, and it was not run with the
+   `--rm` flag, that container will stay on the system until removed, with the status "exited".
+ - "created" containers: If a container is created, e.g. via "docker create", and is never started,
+   it will stay on the system until removed. Note that this is sometimes the desired behavior; the
+   "docker data container" pattern, as described in
+   [the Docker documentation](https://docs.docker.com/engine/tutorials/dockervolumes/#/creating-and-mounting-a-data-volume-container),
+   relies on containers remaining in the "created" state indefinitely. This pattern was the standard
+   way to share persistent data between container until the `docker volume` API was introduced in
+   Docker 1.9
+
+## Usage
+This library provides a single command-line tool `docker-rotate` that supports three subcommands:
+ - `docker-rotate images` - clean up tagged images
+ - `docker-rotate untagged-images` - clean up untagged images
+ - `docker-rotate containers` - clean up containers
+
+### docker-rotate images
+`docker-rotate images` operates on only tagged images. For each image, it determines an image name
+based on the tag, and considers images with the same name together. (For example, images with tags
+"registry.somewhere.com/organization/somename:latest", "organization/somename:3.5", and "organization/somename:old_version" are all considered to
+have the name "organization/somename".)
+
+`docker-rotate images` will never remove an image associated with a container, regardless of the state
+of that container. For that reason, if you plan to clean up containers and images, it's a good idea
+to clean up containers first.
+
+Usage examples:
+
+    # clean up all tagged images, retaining the three most recent images for each image name.
     docker-rotate images --keep 3
 
-    # only target one type of image and don't remove latest
-    docker-rotate images --keep 3 --images "organization/image" "~:latest"
+    # clean up only images matching the specified name, keeping the most recent three
+    docker-rotate images --keep 3 --name "organization/name"
 
-    # don't actually delete anything
-    docker-rotate --dry-run images --keep 3
+    # clean up all images whose tags don't end with ":latest"
+    docker-rotate images --keep 0 --tag "~latest"
 
-    # delete containers exited more than an hour ago
-    docker-rotate containers --exited 1h
+    # clean up only images from the specified organization, never removing those with the "latest" tag.
+    docker-rotate images --keep 3 --name "organization/.*" --tag "~latest"
 
-By default, `docker-rotate` connects to the local Unix socket; the usual environment variables will
-be respected if the `--use-env` flag is given.
+### docker-rotate untagged-images
+`docker-rotate untagged-images` simply removes all images without tags, except images that are in
+use by containers. (Again, that means it's a good idea to clean up containers first.)
+
+### docker-rotate containers
+`docker-rotate containers` cleans up containers according to the arguments you specify. (For
+containers with volumes, those volumes will not be removed.)
+
+    # clean up all "exited" containers that stopped at least one hour ago
+    docker-rotate container --exited 1h
+
+    # clean up all "created" containers that were created at least one day ago
+    docker-rotate containers --created 1d
+
+    # clean up all "dead" containers that stopped at least 10 minutes ago
+    docker-rotate containers --dead 10m
+
+    # clean up containers in multiple states at once
+    docker-rotate container --exited 1h --created 7d --dead 0
+
+`docker-rotate` respects the usual DOCKER_* environment variables when connecting to the Docker
+engine.
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ This library provides a single command-line tool `docker-rotate` that supports t
  - `docker-rotate untagged-images` - clean up untagged images
  - `docker-rotate containers` - clean up containers
 
+`docker-rotate` respects the usual DOCKER_* environment variables when connecting to the Docker
+engine. For documentation on those, see:
+https://docs.docker.com/engine/reference/commandline/cli/#/environment-variables
+
 ### docker-rotate images
 `docker-rotate images` operates on only tagged images. For each image, it determines an image name
 based on the tag, and considers images with the same name together. (For example, images with tags
@@ -60,9 +64,16 @@ Usage examples:
 `docker-rotate untagged-images` simply removes all images without tags, except images that are in
 use by containers. (Again, that means it's a good idea to clean up containers first.)
 
+Usage examples:
+
+    # clean up untagged images
+    docker-rotate untagged-images
+
 ### docker-rotate containers
 `docker-rotate containers` cleans up containers according to the arguments you specify. (For
 containers with volumes, those volumes will not be removed.)
+
+Usage examples:
 
     # clean up all "exited" containers that stopped at least one hour ago
     docker-rotate container --exited 1h
@@ -75,7 +86,4 @@ containers with volumes, those volumes will not be removed.)
 
     # clean up containers in multiple states at once
     docker-rotate container --exited 1h --created 7d --dead 0
-
-`docker-rotate` respects the usual DOCKER_* environment variables when connecting to the Docker
-engine.
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Usage:
     # delete all but the three most recent images of each type
     docker-rotate images --keep 3
 
-    # only target one type of image but don't remove latest
-    docker-rotate images --keep 3 --image "organization/image" "~:latest"
+    # only target one type of image and don't remove latest
+    docker-rotate images --keep 3 --images "organization/image" "~:latest"
 
-    # don't actualy delete anything
+    # don't actually delete anything
     docker-rotate --dry-run images --keep 3
 
     # delete containers exited more than an hour ago
@@ -22,3 +22,4 @@ Usage:
 
 By default, `docker-rotate` connects to the local Unix socket; the usual environment variables will
 be respected if the `--use-env` flag is given.
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,46 @@
+nodes = [
+  { :hostname => 'vagrant-test-docker19',
+    :ip => '172.16.218.3',
+    :box => 'bento/ubuntu-14.04',
+    :ram => 128,
+    :cpus => 1,
+    :docker_version => '1.9.1'},
+  { :hostname => 'vagrant-test-docker111',
+    :ip => '172.16.218.4',
+    :box => 'bento/ubuntu-14.04',
+    :ram => 128,
+    :cpus => 1,
+    :docker_version => '1.11.2'},
+]
+Vagrant.require_version ">= 1.6"
+Vagrant.configure("2") do |config|
+  config.ssh.insert_key = false
+
+  if Vagrant.has_plugin?('vagrant-cachier')
+    config.cache.enable :apt
+  else
+    printf("** Install vagrant-cachier plugin to speedup deploy: `vagrant plugin install vagrant-cachier`.**\n")
+  end
+
+  nodes.each do |node|
+    config.vm.define node[:hostname] do |node_config|
+      node_config.vm.box = node[:box]
+      node_config.vm.host_name = node[:hostname]
+      node_config.vm.network :private_network, ip: node[:ip]
+      node_config.vm.provider :virtualbox do |vb|
+        vb.memory = node[:ram]
+        vb.cpus = node[:cpus]
+        vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+        vb.customize ['guestproperty', 'set', :id, '/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold', 10000]
+      end
+      node_config.vm.provider "vmware_fusion" do |vb|
+        vb.vmx["memsize"] = node[:ram]
+        vb.vmx["numvcpus"] = node[:cpus]
+      end
+      node_config.vm.provision "shell", path: "vagrant/setup_docker.sh", args: node[:docker_version]
+      node_config.vm.synced_folder "./", "/source" 
+    end
+  end
+end
+
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,6 +11,12 @@ nodes = [
     :ram => 128,
     :cpus => 1,
     :docker_version => '1.11.2'},
+  { :hostname => 'vagrant-test-docker112',
+    :ip => '172.16.218.5',
+    :box => 'bento/ubuntu-14.04',
+    :ram => 128,
+    :cpus => 1,
+    :docker_version => '1.12.0'},
 ]
 Vagrant.require_version ">= 1.6"
 Vagrant.configure("2") do |config|

--- a/dockerrotate/filter.py
+++ b/dockerrotate/filter.py
@@ -1,22 +1,26 @@
+"""
+Contains functions used in implementing image name filtering.
+"""
 import re
 
 
-def include_image(image_tags, args):
+def regex_positive_match(pattern, value):
     """
-    Return truthy if image should be considered for removal.
-    """
-    if not args.images:
-        return True
-
-    return all(regex_match(pattern, tag)
-               for pattern in args.images
-               for tag in image_tags)
-
-
-def regex_match(pattern, tag):
-    """
-    Perform a regex match on the tag.
+    Return False if the regex is "positive" and is NOT a complete match for
+    the supplied value, True otherwise.
     """
     if pattern[0] == '~':
-        return not re.search(pattern[1:], tag)
-    return re.search(pattern, tag)
+        # this is a negative regex, ignore
+        return True
+    return re.match(pattern + '\Z', value)
+
+
+def regex_negative_match(pattern, value):
+    """
+    Return False if the regex is "negative" and is a complete match for the
+    supplied value, True otherwise.
+    """
+    if pattern[0] != '~':
+        # this is a positive regex, ignore
+        return True
+    return not re.match(pattern[1:] + '\Z', value)

--- a/dockerrotate/images.py
+++ b/dockerrotate/images.py
@@ -1,63 +1,141 @@
+"""
+Code to manage the cleanup of images with one or more tags.
+
+The logic here is:
+ - identify all images we should retain based on the "keep" argument
+ - also identify all images that are in use
+ - then, find all images that match our filters and aren't in the first two sets
+
+Evaluation of "keep" is done on a global basis to avoid situations like this:
+ - image A has repotags "foo:image1" and "bar:image1", and timestamp N
+ - image B has repotag "foo:image2", and timestamp >N
+ - the command is run with "--keep 1 --name foo"
+
+... the situation is a bit ambiguous, but an approach that errs on the side of not deleting
+things is best.
+
+We *could* also skip the "identify images in use" check, just attempt to delete all of the images,
+and rely on Docker blocking the deletion of images that are being used by containers. While that
+would simplify the code and might improve runtime a hair, then the tool would generate error output
+even when functioning as intended - not a good practice for a tool, as that makes it difficult to
+detect real errors.
+"""
 from collections import defaultdict
 
 from docker.errors import APIError
 
-from dockerrotate.filter import include_image
+from dockerrotate.filter import regex_positive_match, regex_negative_match
+
+
+def determine_images_to_remove(images, containers, args):
+    # Accept images and containers as inputs to make this easier to test
+
+    # see docstring for explanation of what's going on here.
+    image_ids_to_keep = find_image_ids_to_keep(images, args)
+    image_ids_in_use = _find_image_ids_in_use(containers)
+
+    def matches_filters(image):
+        # Images can have multiple names. Allow deletion if:
+        #  - ANY of the names matches all of the positive expressions
+        #  - ALL of the names pass (i.e don't match ALL of the negative expressions
+
+        def positive_check(name, tag):
+            # return true if the name and tag are accepted by all positive regexes
+            return (all(regex_positive_match(name_pattern, name) for name_pattern in args.name) and
+                    all(regex_positive_match(tag_pattern, tag) for tag_pattern in args.tag))
+
+        def negative_check(name, tag):
+            # return true if the name and tag aren't rejected by any of the negative regexes
+            return (all(regex_negative_match(name_pattern, name) for name_pattern in args.name) and
+                    all(regex_negative_match(tag_pattern, tag) for tag_pattern in args.tag))
+
+        name_tags = [(normalize_tag_name(name_tag), tag_value(name_tag))
+                     for name_tag in image["RepoTags"]]
+
+        return any(positive_check(name, tag) for name, tag in name_tags) and \
+            all(negative_check(name, tag) for name, tag in name_tags)
+
+    return [image for image in images
+            if image["Id"] not in image_ids_to_keep and
+            image["Id"] not in image_ids_in_use and
+            matches_filters(image)]
+
+
+def find_image_ids_to_keep(images, args):
+    number_to_keep = args.keep
+
+    # Need a special case for keep = 0; below, we use a [-number:] range on a list to
+    # pick out the items to keep, and that doesn't work with a zero, because -0 == 0.
+    # Luckily, the zero case is easy to calculate..
+    if number_to_keep == 0:
+        return set()
+
+    images_by_name = defaultdict(list)
+    for image in images:
+        # each RepoTag produces a name; these are usually the same but can be different.
+        image_names = set(normalize_tag_name(name_tag) for name_tag in image["RepoTags"])
+        for image_name in image_names:
+            images_by_name[image_name].append(image)
+
+    all_ids_to_keep = set()
+    for image_name, images_with_name in images_by_name.items():
+        images_to_keep = sorted(images_with_name,
+                                key=lambda image: image["Created"])[-number_to_keep:]
+        all_ids_to_keep.update(image["Id"] for image in images_to_keep)
+
+    return all_ids_to_keep
+
+
+def _find_image_ids_in_use(containers):
+    return set(container["ImageID"] for container in containers)
 
 
 def clean_images(args):
     """
-    Delete old images keeping the most recent N images by tag.
+    Main entry point - delete old images keeping the most recent N images by tag.
     """
+
     # should not need to inspect all images; only intermediate images should appear
     # when all is true; these should be deleted along with dependent images
-    images = [image
-              for image in args.client.images(all=False)
-              if include_image(image["RepoTags"], args)]
+    images = args.client.images(all=False)
+    containers = args.client.containers(all=True)
 
-    # index by id
-    images_by_id = {
-        image["Id"]: image for image in images
-    }
+    images_to_remove = determine_images_to_remove(images, containers, args)
 
-    # group by name
-    images_by_name = defaultdict(set)
-    for image in images:
-        for tag in image["RepoTags"]:
-            image_name = normalize_tag_name(tag)
-            images_by_name[image_name].add(image["Id"])
+    for image in images_to_remove:
+        print "Removing image ID: {}, Tags: {}".format(
+            image["Id"],
+            ", ".join(image["RepoTags"])
+        )
 
-    for image_name, image_ids in images_by_name.items():
-        # sort/keep
-        images_to_delete = sorted([
-            images_by_id[image_id] for image_id in image_ids],
-            key=lambda image: -image["Created"],
-        )[args.keep:]
+        if args.dry_run:
+            continue
 
-        # delete
-        for image in images_to_delete:
-            print "Removing image ID: {}, Tags: {}".format(
-                image["Id"],
-                ", ".join(image["RepoTags"])
-            )
-
-            if args.dry_run:
-                continue
-
-            try:
-                args.client.remove_image(image["Id"], force=True, noprune=False)
-            except APIError as error:
-                print error.message
+        try:
+            # force=true is required here because the image we remove might be "latest".
+            args.client.remove_image(image["Id"], force=True, noprune=False)
+        except APIError as error:
+            print "unexpected: API error while trying to delete image. Error message is:"
+            print error.message
 
 
-def normalize_tag_name(tag):
+def normalize_tag_name(name_tag):
     """
-    docker-py provides image names with tags as a single string.
+    docker-py provides "RepoTags", which are strings of format "<image name>:<image tag>"
 
-    We want:
+    We want to strip off the tag part and normalize the name:
 
        some.domain.com/organization/image:tag -> organization/image
                        organization/image:tag -> organization/image
                                     image:tag ->              image
     """
-    return "/".join(tag.rsplit(":", 1)[0].split("/")[-2:])
+    return "/".join(name_tag.rsplit(":", 1)[0].split("/")[-2:])
+
+
+def tag_value(name_tag):
+    """
+    docker-py provides "RepoTags", which are strings of format "<image name>:<image tag>"
+
+    We want just the part after the colon.
+    """
+    return name_tag.rsplit(":", 1)[1]

--- a/dockerrotate/main.py
+++ b/dockerrotate/main.py
@@ -13,7 +13,7 @@ from dockerrotate.containers import clean_containers
 UNIX_SOC_ARGS = {"base_url": "unix://var/run/docker.sock"}
 
 
-def parse_args():
+def parse_args(arg_values=None):
     parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
     parser.add_argument(
         "-e", "--use-env",
@@ -48,7 +48,7 @@ def parse_args():
     images_parser.add_argument(
         "--images",
         nargs='*',
-        help="Python regex of image names to remove. Use a '~' prefix for negative match.",
+        help="Python regexes of image names to remove. Use a '~' prefix for negative match.",
     )
 
     containers_parser = subparsers.add_parser(
@@ -65,7 +65,7 @@ def parse_args():
     containers_parser.add_argument(
         "--created",
         default="1d",
-        help="Remove only containers that where created (but not running) that long ago",
+        help="Remove only containers that were created (but not running) that long ago",
     )
     containers_parser.add_argument(
         "--images",
@@ -73,7 +73,7 @@ def parse_args():
         help="Python regex of image names to remove. Use a '~' prefix for negative match.",
     )
 
-    return parser.parse_args()
+    return parser.parse_args(arg_values)
 
 
 def make_client(args):
@@ -100,11 +100,12 @@ def make_client(args):
     return client
 
 
-def main():
+def main(arg_values=None):
     """
     CLI entry point.
+    Allow arg values to be passed in for testing reasons.
     """
-    args = parse_args()
+    args = parse_args(arg_values)
     args.client = make_client(args)
 
     args.cmd(args)

--- a/dockerrotate/main.py
+++ b/dockerrotate/main.py
@@ -1,25 +1,42 @@
 """
 Free up space by rotating out old Docker images and containers.
 """
-from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter
+from argparse import ArgumentParser, ArgumentDefaultsHelpFormatter, ArgumentTypeError
+from datetime import datetime, timedelta
+import re
 
+from dateutil.tz import tzutc
 from docker import Client
 from docker.errors import NotFound
 from docker.utils import kwargs_from_env
 
-from dockerrotate.images import clean_images
 from dockerrotate.containers import clean_containers
+from dockerrotate.images import clean_images
+from dockerrotate.untagged import clean_untagged
+
 
 UNIX_SOC_ARGS = {"base_url": "unix://var/run/docker.sock"}
 
+TIME_REGEX = re.compile(r'((?P<days>\d+?)d)?((?P<hours>\d+?)h)?((?P<minutes>\d+?)m)?((?P<seconds>\d+?)s)?')  # noqa
 
-def parse_args(arg_values=None):
+
+def time_delta_type(time_str):
+    """
+    Parse a human readable time delta string into a timedelta object
+    """
+    parts = TIME_REGEX.match(time_str)
+    if not parts:
+        raise ArgumentTypeError("Invalid time delta format '{}'".format(time_str))
+    parts = parts.groupdict()
+    time_params = {}
+    for (name, param) in parts.iteritems():
+        if param:
+            time_params[name] = int(param)
+    return timedelta(**time_params)
+
+
+def argument_parser():
     parser = ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatter)
-    parser.add_argument(
-        "-e", "--use-env",
-        action="store_true",
-        help="Load docker connection information from standard environment variables.",
-    )
     parser.add_argument(
         "--dry-run",
         action="store_true",
@@ -30,50 +47,77 @@ def parse_args(arg_values=None):
         help="Specify client version to use.",
     )
 
-    subparsers = parser.add_subparsers()
+    subparsers = parser.add_subparsers(title="Subcommands")
 
     images_parser = subparsers.add_parser(
         "images",
-        help="Clean out old images",
+        help="Clean up old tagged images",
         formatter_class=ArgumentDefaultsHelpFormatter,
+        epilog="Multiple \"--name\" and \"--tag\" arguments can be provided. Only images that "
+               "match ALL of the supplied expressions will be considered for cleanup."
     )
-    images_parser.set_defaults(cmd=clean_images)
+    images_parser.set_defaults(func=clean_images)
     images_parser.add_argument(
         "--keep",
         "-k",
         type=int,
-        default=3,
-        help="Keep this many images of each kind",
+        required=True,
+        help="For each image name, keep this many images",
+    )
+
+    images_parser.add_argument(
+        "--name",
+        action="append",
+        default=[],
+        help="Limit cleanup to images whose name fully matches this (python) regular expression. "
+             "Use a '~' prefix to invert matching.",
     )
     images_parser.add_argument(
-        "--images",
-        nargs='*',
-        help="Python regexes of image names to remove. Use a '~' prefix for negative match.",
+        "--tag",
+        action="append",
+        default=[],
+        help="Limit cleanup to images whose tag fully matches this (python) regular expression. "
+             "Use a '~' prefix to invert matching.",
     )
+
+    untagged_parser = subparsers.add_parser(
+        "untagged-images",
+        help="Clean out old untagged images",
+        formatter_class=ArgumentDefaultsHelpFormatter,
+    )
+    untagged_parser.set_defaults(func=clean_untagged)
 
     containers_parser = subparsers.add_parser(
         "containers",
         help="Clean out old containers",
         formatter_class=ArgumentDefaultsHelpFormatter,
+        epilog="The \"exited\", \"created\", and \"dead\" arguments all "
     )
-    containers_parser.set_defaults(cmd=clean_containers)
+    containers_parser.set_defaults(func=clean_containers)
     containers_parser.add_argument(
         "--exited",
-        default="1h",
-        help="Remove only containers that exited that long ago",
+        type=time_delta_type,
+        help="Remove \"exited\" containers that finished at least this long ago",
     )
     containers_parser.add_argument(
         "--created",
-        default="1d",
-        help="Remove only containers that were created (but not running) that long ago",
+        type=time_delta_type,
+        help="Remove \"created\" containers that were created at least this long ago",
     )
     containers_parser.add_argument(
-        "--images",
-        nargs='*',
-        help="Python regex of image names to remove. Use a '~' prefix for negative match.",
+        "--dead",
+        type=time_delta_type,
+        help="Remove \"dead\" containers that finished at least this long ago",
     )
 
-    return parser.parse_args(arg_values)
+    return parser
+
+
+def parse_arguments(arg_values):
+    parser = argument_parser()
+    args = parser.parse_args(arg_values)
+    args.now = datetime.now(tzutc())
+    return args
 
 
 def make_client(args):
@@ -84,7 +128,7 @@ def make_client(args):
     variables (e.g. DOCKER_HOST). This is much simpler than trying to pass
     all the possible certificate options through argparse.
     """
-    kwargs = kwargs_from_env(assert_hostname=False) if args.use_env else UNIX_SOC_ARGS
+    kwargs = kwargs_from_env(assert_hostname=False)
 
     if args.client_version:
         kwargs["version"] = args.client_version
@@ -105,7 +149,8 @@ def main(arg_values=None):
     CLI entry point.
     Allow arg values to be passed in for testing reasons.
     """
-    args = parse_args(arg_values)
+    args = parse_arguments(arg_values)
+
     args.client = make_client(args)
 
-    args.cmd(args)
+    args.func(args)

--- a/dockerrotate/untagged.py
+++ b/dockerrotate/untagged.py
@@ -1,0 +1,36 @@
+"""
+Code to handle the removal of untagged images. While it's possible to handle untagged image
+cleanup with command line utilities alone, using something like:
+
+   docker images -f dangling=true -q | xargs docker rmi
+
+... it also makes sense to consolidate cleanup in a single tool. (I note that, in the case
+where an untagged image is in use, the above will generate an error message, whereas the code
+here is smart enough not to try to delete images that are in use.)
+"""
+from docker.errors import APIError
+
+
+def _find_image_ids_in_use(containers):
+    return set(container["ImageID"] for container in containers)
+
+
+def clean_untagged(args):
+    containers = args.client.containers(all=True)
+    untagged_images = args.client.images(filters=dict(dangling=True))
+    image_ids_in_use = _find_image_ids_in_use(containers)
+
+    for image in untagged_images:
+        if image["Id"] in image_ids_in_use:
+            continue
+
+        print "Removing untagged image with Id: {}".format(image["Id"])
+
+        if args.dry_run:
+            continue
+
+        try:
+            args.client.remove_image(image["Id"], noprune=False)
+        except APIError as error:
+            print "unexpected: API error while trying to delete untagged image. Error message is:"
+            print error.message

--- a/integration_test/README
+++ b/integration_test/README
@@ -1,0 +1,11 @@
+This file contains integration tests for Docker containers. These integration tests need a Docker
+instance to run against, and they will use your local container. While the tests do attempt to
+clean up after themselves, that does mean:
+
+ - if you don't have a docker instance available, nothing will work.
+ - if everything is working correctly, running the tests will "clean up" your local Docker instance,
+   equivalent to running "docker-rotate images --keep 5".
+ - if things are NOT working correctly, this could remove any number of images or containers from
+   your local docker instance.
+
+Ideally, therefore, you'll want to run them in some kind of protected environment, like Vagrant.

--- a/integration_test/conftest.py
+++ b/integration_test/conftest.py
@@ -1,0 +1,93 @@
+
+from docker.errors import NotFound
+import pytest
+
+import io
+import json
+import textwrap
+
+
+@pytest.fixture(scope="module")
+def docker_client():
+    from docker import Client
+    from docker.errors import NotFound
+    from docker.utils import kwargs_from_env
+    kwargs = kwargs_from_env(assert_hostname=False)
+    client = Client(**kwargs)
+
+    # Verify client can talk to server.
+    try:
+        client.version()
+    except NotFound as error:
+        raise SystemExit(error)
+
+    return client
+
+
+DEFAULT_TEST_IMAGE_NAME = 'locationlabs/zzzdockergentestimage'
+
+
+class ImageFactory:
+    def __init__(self, docker_client):
+        self.docker_client = docker_client
+        self.counter = 1
+        self.name = DEFAULT_TEST_IMAGE_NAME
+        self.image_ids = []
+
+    def add(self, tag, *other_tags):
+        self.add_named(self.name, tag, *other_tags)
+
+    def add_named(self, name, tag, *other_tags):
+        dockerfile = textwrap.dedent('''\
+            FROM alpine:3.4
+            MAINTAINER Unit Testing
+
+            RUN echo "Test image {}:{}" > /content.txt
+
+            CMD sleep 999
+            '''.format(name, self.counter))
+        dockerfile_bytes = io.BytesIO(dockerfile.encode('utf-8'))
+
+        self.counter += 1
+        response_gen = self.docker_client.build(
+            fileobj=dockerfile_bytes,
+            tag='{}:{}'.format(name, tag),
+            rm=True,
+            forcerm=True)
+        response = [json.loads(line) for line in response_gen]
+        response_stream = [obj['stream'][0:-1] for obj in response if 'stream' in obj]
+
+        for line in response_stream:
+            print line
+
+        assert response_stream[-1].find('Successfully built') == 0
+
+        # grab and store image id
+        image_id = response_stream[-1].rsplit(' ', 1)[1]
+        print "--> image id is", image_id
+        self.image_ids.append(image_id)
+
+        for other_tag in other_tags:
+            self.docker_client.tag(image_id, name, other_tag, force=True)
+
+    def cleanup(self):
+        cleaned = 0
+        for image_id in self.image_ids:
+            try:
+                self.docker_client.remove_image(image_id, force=True)
+                cleaned += 1
+            except NotFound:
+                pass
+        return cleaned
+
+
+@pytest.yield_fixture
+def image_factory(docker_client):
+    factory = ImageFactory(docker_client)
+    yield factory
+    cleaned = factory.cleanup()
+    print "removed", cleaned, "images in image factory cleanup"
+
+
+
+

--- a/integration_test/conftest.py
+++ b/integration_test/conftest.py
@@ -1,84 +1,24 @@
-
-from docker.errors import NotFound
+"""
+Contains pytest fixtures to be used by tests.
+"""
+from docker import Client
+from docker.utils import kwargs_from_env
 import pytest
 
-import io
-import json
-import textwrap
+from imagetools import ImageFactory
+from containertools import ContainerFactory
 
 
 @pytest.fixture(scope="module")
 def docker_client():
-    from docker import Client
-    from docker.errors import NotFound
-    from docker.utils import kwargs_from_env
     kwargs = kwargs_from_env(assert_hostname=False)
     client = Client(**kwargs)
 
     # Verify client can talk to server.
-    try:
-        client.version()
-    except NotFound as error:
-        raise SystemExit(error)
+    # If not, we'll see NotFound here and testing will stop.
+    client.version()
 
     return client
-
-
-DEFAULT_TEST_IMAGE_NAME = 'locationlabs/zzzdockertestimage'
-
-
-class ImageFactory:
-    def __init__(self, docker_client, name=DEFAULT_TEST_IMAGE_NAME):
-        self.docker_client = docker_client
-        self.counter = 1
-        self.name = name
-        self.image_ids = []
-
-    def add(self, tag, *other_tags):
-        self.add_named(self.name, tag, *other_tags)
-
-    def add_named(self, name, tag, *other_tags):
-        dockerfile = textwrap.dedent('''\
-            FROM alpine:3.4
-            MAINTAINER Unit Testing
-
-            RUN echo "Test image {}:{}" > /content.txt
-
-            CMD sleep 999
-            '''.format(name, self.counter))
-        dockerfile_bytes = io.BytesIO(dockerfile.encode('utf-8'))
-
-        self.counter += 1
-        response_gen = self.docker_client.build(
-            fileobj=dockerfile_bytes,
-            tag='{}:{}'.format(name, tag),
-            rm=True,
-            forcerm=True)
-        response = [json.loads(line) for line in response_gen]
-        response_stream = [obj['stream'][0:-1] for obj in response if 'stream' in obj]
-
-        for line in response_stream:
-            print line
-
-        assert response_stream[-1].find('Successfully built') == 0
-
-        # grab and store image id
-        image_id = response_stream[-1].rsplit(' ', 1)[1]
-        print "--> image id is", image_id
-        self.image_ids.append(image_id)
-
-        for other_tag in other_tags:
-            self.docker_client.tag(image_id, name, other_tag, force=True)
-
-    def cleanup(self):
-        cleaned = 0
-        for image_id in self.image_ids:
-            try:
-                self.docker_client.remove_image(image_id, force=True)
-                cleaned += 1
-            except NotFound:
-                pass
-        return cleaned
 
 
 @pytest.yield_fixture
@@ -87,62 +27,6 @@ def image_factory(docker_client):
     yield factory
     cleaned = factory.cleanup()
     print "removed", cleaned, "images in image factory cleanup"
-
-
-CONTAINER_TEST_IMAGE_NAME = 'locationlabs/zzzdockertestimage_for_containers'
-
-class ContainerFactory:
-    def __init__(self, docker_client):
-        self.docker_client = docker_client
-        self.image_factory = ImageFactory(docker_client, CONTAINER_TEST_IMAGE_NAME)
-        self.image_factory.add("image_0", "latest")
-        self.image_specifier = CONTAINER_TEST_IMAGE_NAME
-        self.container_ids = []
-
-    def _create(self, image_specifier=None):
-        response = self.docker_client.create_container(
-            image=(image_specifier or self.image_specifier))
-        return response["Id"]
-
-    def make_created(self, image_specifier=None):
-        container_id = self._create(image_specifier)
-        self.container_ids.append(container_id)
-        return container_id
-
-    def make_running(self, image_specifier=None):
-        container_id = self._create(image_specifier)
-        self.container_ids.append(container_id)
-        self.docker_client.start(container_id)
-        return container_id
-
-    def make_stopped(self, image_specifier=None):
-        container_id = self._create(image_specifier)
-        self.container_ids.append(container_id)
-        self.docker_client.start(container_id)
-
-        started = False
-        for counter in range(100):
-            info = self.docker_client.inspect_container(container_id)
-            state = info["State"]["Status"]
-            if state == "running":
-                started = True
-                break
-            time.sleep(0.5)
-        assert started
-
-        self.docker_client.stop(container_id)
-
-        return container_id
-
-    def cleanup(self):
-        # some containers may have already been removed
-        container_infos = self.docker_client.containers(all=True)
-        existing_container_ids = set(container_info['Id'] for container_info in container_infos)
-
-        for container_id in self.container_ids:
-            if container_id in existing_container_ids:
-                self.docker_client.remove_container(container_id, force=True)
-        self.image_factory.cleanup()
 
 
 @pytest.yield_fixture

--- a/integration_test/containertools.py
+++ b/integration_test/containertools.py
@@ -1,0 +1,60 @@
+import pytest
+
+from imagetools import ImageFactory
+
+class ContainerFactory:
+    IMAGE_NAME = 'locationlabs/zzzdockertestimage_for_containers'
+    IMAGE_TAG = 'image_0'
+
+    def __init__(self, docker_client):
+        self.docker_client = docker_client
+        self.image_factory = ImageFactory(docker_client, self.IMAGE_NAME)
+        self.image_id = self.image_factory.add(self.IMAGE_TAG, "latest")
+
+        self.image_specifier = self.IMAGE_NAME
+        self.container_ids = []
+
+    def _create(self, image_specifier=None):
+        response = self.docker_client.create_container(
+            image=(image_specifier or self.image_specifier))
+        return response["Id"]
+
+    def make_created(self, image_specifier=None):
+        container_id = self._create(image_specifier)
+        self.container_ids.append(container_id)
+        return container_id
+
+    def make_running(self, image_specifier=None):
+        container_id = self._create(image_specifier)
+        self.container_ids.append(container_id)
+        self.docker_client.start(container_id)
+        return container_id
+
+    def make_stopped(self, image_specifier=None):
+        container_id = self._create(image_specifier)
+        self.container_ids.append(container_id)
+        self.docker_client.start(container_id)
+
+        started = False
+        for counter in range(100):
+            info = self.docker_client.inspect_container(container_id)
+            state = info["State"]["Status"]
+            if state == "running":
+                started = True
+                break
+            time.sleep(0.2)
+        assert started
+
+        self.docker_client.stop(container_id)
+
+        return container_id
+
+    def cleanup(self):
+        # some containers may have already been removed
+        container_infos = self.docker_client.containers(all=True)
+        existing_container_ids = set(container_info['Id'] for container_info in container_infos)
+
+        for container_id in self.container_ids:
+            if container_id in existing_container_ids:
+                self.docker_client.remove_container(container_id, force=True)
+        self.image_factory.cleanup()

--- a/integration_test/imagetools.py
+++ b/integration_test/imagetools.py
@@ -1,0 +1,104 @@
+import io
+import json
+import textwrap
+import time
+
+from docker.errors import NotFound
+import pytest
+
+
+DEFAULT_TEST_IMAGE_NAME = 'locationlabs/zzzdockertestimage'
+BASE_IMAGE = "alpine:3.4"
+
+
+def _normalize_image_id(image_id):
+    """
+    The image IDs we get back from parsing "docker build output are abbreviated, 12 hex digits long.
+    In order to compare them to the ids we get from "docker.Client.images()" calls, we need to
+    normalize them
+    """
+    if image_id is None:
+        return None
+
+    if image_id.startswith("sha256:"):
+        image_id = image_id[len("sha256:"):]
+    return image_id[0:12]
+
+
+def assert_images(docker_client, *image_ids):
+    """
+    Verify that, except for the base image used by ImageFactory, only the specifed images exist.
+    """
+    existing_image_ids = [_normalize_image_id(image["Id"]) for image in docker_client.images()
+                          if BASE_IMAGE not in image["RepoTags"]]
+    assert set(existing_image_ids) == set(_normalize_image_id(image_id) for image_id in image_ids)
+    assert len(existing_image_ids) == len(image_ids)
+
+
+class ImageFactory:
+    def __init__(self, docker_client, name=DEFAULT_TEST_IMAGE_NAME):
+        self.docker_client = docker_client
+        self.counter = 1
+        self.name = name
+        self.image_ids = []
+
+    def add(self, tag, *other_tags):
+        return self.add_named(self.name, tag, *other_tags)
+
+    def add_named(self, name, tag, *other_tags):
+
+        # The "Created" timestamp on images has 1-second granuarity.
+        # So if we create images too quickly, the order of creation won't necessarily match
+        # the order we get when we sort containers by the "Created" field - and our unit tests
+        # won't do what we expect.
+        # So, add an automatic delay to the image factory to avoid this issue.
+        # (This is a simple implementation that is guaranteed to do the job. I tried a more complex
+        # solution, but I was surprised to see that waiting 1 second is sometimes not enough.)
+        if self.counter != 1:
+            time.sleep(2)
+
+        dockerfile = textwrap.dedent("""\
+            FROM {base_image}
+            MAINTAINER Unit Testing
+
+            RUN echo "Test image {name}:{counter}" > /content.txt
+
+            CMD sleep 999
+            """.format(base_image=BASE_IMAGE, name=name, counter=self.counter))
+        dockerfile_bytes = io.BytesIO(dockerfile.encode('utf-8'))
+
+        self.counter += 1
+        response_gen = self.docker_client.build(
+            fileobj=dockerfile_bytes,
+            tag='{}:{}'.format(name, tag),
+            rm=True,
+            forcerm=True)
+        response = [json.loads(line) for line in response_gen]
+        response_stream = [obj['stream'][0:-1] for obj in response if 'stream' in obj]
+
+        for line in response_stream:
+            print line
+
+        assert response_stream[-1].find('Successfully built') == 0
+
+        # grab and store image id
+        image_id = response_stream[-1].rsplit(' ', 1)[1]
+        self.image_ids.append(image_id)
+
+        for other_tag in other_tags:
+            self.docker_client.tag(image_id, name, other_tag, force=True)
+
+        return image_id
+
+    def cleanup(self):
+        cleaned = 0
+        for image_id in self.image_ids:
+            try:
+                self.docker_client.remove_image(image_id, force=True)
+                cleaned += 1
+            except NotFound:
+                pass
+        return cleaned
+
+
+

--- a/integration_test/test_containers.py
+++ b/integration_test/test_containers.py
@@ -1,6 +1,6 @@
-from dockerrotate.main import main
-
 import pytest
+
+from dockerrotate.main import main
 
 
 def _totals(docker_client):
@@ -102,77 +102,80 @@ def test_time_exclusion(docker_client, container_factory):
     _assert_existing(docker_client, c1, r1, s1)
     _assert_running(docker_client, r1)
 
-
-def test_name_matching(docker_client, container_factory):
-
-    CONTAINER_TEST_IMAGE_MATCH_NAME = 'locationlabs/zzzdockertestimage_for_container_matching'
-
-    _assert_no_containers(docker_client)
-
-    container_factory.image_factory.add_named(CONTAINER_TEST_IMAGE_MATCH_NAME, 'latest')
-
-    c1 = container_factory.make_created()
-    r1 = container_factory.make_running()
-    s1 = container_factory.make_stopped()
-    nc1 = container_factory.make_created(CONTAINER_TEST_IMAGE_MATCH_NAME)
-    nr1 = container_factory.make_running(CONTAINER_TEST_IMAGE_MATCH_NAME)
-    ns1 = container_factory.make_stopped(CONTAINER_TEST_IMAGE_MATCH_NAME)
-
-    _assert_existing(docker_client, c1, r1, s1, nc1, nr1, ns1)
-    _assert_running(docker_client, r1, nr1)
-
-    main(['containers', '--created', '0m', '--exited', '0m', '--images', CONTAINER_TEST_IMAGE_MATCH_NAME])
-
-    _assert_existing(docker_client, c1, r1, s1, nr1)
-    _assert_running(docker_client, r1, nr1)
-
-
-def test_inverse_name_matching(docker_client, container_factory):
-
-    CONTAINER_TEST_IMAGE_MATCH_NAME = 'locationlabs/zzzdockertestimage_for_container_matching'
-
-    _assert_no_containers(docker_client)
-
-    container_factory.image_factory.add_named(CONTAINER_TEST_IMAGE_MATCH_NAME, 'latest')
-
-    c1 = container_factory.make_created()
-    r1 = container_factory.make_running()
-    s1 = container_factory.make_stopped()
-    nc1 = container_factory.make_created(CONTAINER_TEST_IMAGE_MATCH_NAME)
-    nr1 = container_factory.make_running(CONTAINER_TEST_IMAGE_MATCH_NAME)
-    ns1 = container_factory.make_stopped(CONTAINER_TEST_IMAGE_MATCH_NAME)
-    _assert_existing(docker_client, c1, r1, s1, nc1, nr1, ns1)
-    _assert_running(docker_client, r1, nr1)
-
-    main(['containers', '--created', '0m', '--exited', '0m', '--images', "~" + CONTAINER_TEST_IMAGE_MATCH_NAME])
-
-    _assert_existing(docker_client, r1, nc1, nr1, ns1)
-    _assert_running(docker_client, r1, nr1)
-
-
-def test_label_matching(docker_client, container_factory):
-
-    LABEL = 'other_label'
-
-    _assert_no_containers(docker_client)
-
-    container_factory.image_factory.add(LABEL)
-    image_specifier = '{}:{}'.format(container_factory.image_factory.name, LABEL)
-
-    # create containers with the "latest" label and without
-    c1 = container_factory.make_created()
-    r1 = container_factory.make_running()
-    s1 = container_factory.make_stopped()
-    lc1 = container_factory.make_created(image_specifier)
-    lr1 = container_factory.make_running(image_specifier)
-    ls1 = container_factory.make_stopped(image_specifier)
-
-    _assert_existing(docker_client, c1, r1, s1, lc1, lr1, ls1)
-    _assert_running(docker_client, r1, lr1)
-
-    # clean up containers that are not using the latest image
-    main(['containers', '--created', '0m', '--exited', '0m', '--images', "~:other_label"])
-
-    _assert_existing(docker_client, r1, lc1, lr1, ls1)
-    _assert_running(docker_client, r1, lr1)
+#
+# Name and tag matching for containers was dropped as part of the 3.0 release.
+# If we add it back at some point, here are integration tests for it.
+#
+# def test_name_matching(docker_client, container_factory):
+#
+#     CONTAINER_TEST_IMAGE_MATCH_NAME = 'locationlabs/zzzdockertestimage_for_container_matching'
+#
+#     _assert_no_containers(docker_client)
+#
+#     container_factory.image_factory.add_named(CONTAINER_TEST_IMAGE_MATCH_NAME, 'latest')
+#
+#     c1 = container_factory.make_created()
+#     r1 = container_factory.make_running()
+#     s1 = container_factory.make_stopped()
+#     nc1 = container_factory.make_created(CONTAINER_TEST_IMAGE_MATCH_NAME)
+#     nr1 = container_factory.make_running(CONTAINER_TEST_IMAGE_MATCH_NAME)
+#     ns1 = container_factory.make_stopped(CONTAINER_TEST_IMAGE_MATCH_NAME)
+#
+#     _assert_existing(docker_client, c1, r1, s1, nc1, nr1, ns1)
+#     _assert_running(docker_client, r1, nr1)
+#
+#     main(['containers', '--created', '0m', '--exited', '0m', '--name', CONTAINER_TEST_IMAGE_MATCH_NAME])
+#
+#     _assert_existing(docker_client, c1, r1, s1, nr1)
+#     _assert_running(docker_client, r1, nr1)
+#
+#
+# def test_inverse_name_matching(docker_client, container_factory):
+#
+#     CONTAINER_TEST_IMAGE_MATCH_NAME = 'locationlabs/zzzdockertestimage_for_container_matching'
+#
+#     _assert_no_containers(docker_client)
+#
+#     container_factory.image_factory.add_named(CONTAINER_TEST_IMAGE_MATCH_NAME, 'latest')
+#
+#     c1 = container_factory.make_created()
+#     r1 = container_factory.make_running()
+#     s1 = container_factory.make_stopped()
+#     nc1 = container_factory.make_created(CONTAINER_TEST_IMAGE_MATCH_NAME)
+#     nr1 = container_factory.make_running(CONTAINER_TEST_IMAGE_MATCH_NAME)
+#     ns1 = container_factory.make_stopped(CONTAINER_TEST_IMAGE_MATCH_NAME)
+#     _assert_existing(docker_client, c1, r1, s1, nc1, nr1, ns1)
+#     _assert_running(docker_client, r1, nr1)
+#
+#     main(['containers', '--created', '0m', '--exited', '0m', '--name', "~" + CONTAINER_TEST_IMAGE_MATCH_NAME])
+#
+#     _assert_existing(docker_client, r1, nc1, nr1, ns1)
+#     _assert_running(docker_client, r1, nr1)
+#
+#
+# def test_label_matching(docker_client, container_factory):
+#
+#     LABEL = 'other_label'
+#
+#     _assert_no_containers(docker_client)
+#
+#     container_factory.image_factory.add(LABEL)
+#     image_specifier = '{}:{}'.format(container_factory.image_factory.name, LABEL)
+#
+#     # create containers with the "latest" label and without
+#     c1 = container_factory.make_created()
+#     r1 = container_factory.make_running()
+#     s1 = container_factory.make_stopped()
+#     lc1 = container_factory.make_created(image_specifier)
+#     lr1 = container_factory.make_running(image_specifier)
+#     ls1 = container_factory.make_stopped(image_specifier)
+#
+#     _assert_existing(docker_client, c1, r1, s1, lc1, lr1, ls1)
+#     _assert_running(docker_client, r1, lr1)
+#
+#     # clean up containers that are not using the latest image
+#     main(['containers', '--created', '0m', '--exited', '0m', '--images', "~:other_label"])
+#
+#     _assert_existing(docker_client, r1, lc1, lr1, ls1)
+#     _assert_running(docker_client, r1, lr1)
 

--- a/integration_test/test_containers.py
+++ b/integration_test/test_containers.py
@@ -1,0 +1,178 @@
+from dockerrotate.main import main
+
+import pytest
+
+
+def _totals(docker_client):
+    return (len(docker_client.containers()), len(docker_client.containers(all=True)))
+
+def _assert_no_containers(docker_client):
+    # common precondition: no existing containers
+    assert docker_client.containers(all=True) == []
+
+def _assert_existing(docker_client, *ids):
+    existing_container_ids = set(container["Id"] for container in docker_client.containers(all=True))
+    assert existing_container_ids == set(ids)
+
+def _assert_running(docker_client, *ids):
+    existing_container_ids = set(container["Id"] for container in docker_client.containers())
+    assert existing_container_ids == set(ids)
+
+def test_remove_created_containers(docker_client, container_factory):
+
+    _assert_no_containers(docker_client)
+
+    c1 = container_factory.make_created()
+    c2 =container_factory.make_created()
+    r1 = container_factory.make_running()
+    s1 = container_factory.make_stopped()
+    _assert_existing(docker_client, c1, c2, r1, s1)
+    _assert_running(docker_client, r1)
+
+    main(['containers', '--created', '0h',])
+
+    _assert_existing(docker_client, r1, s1)
+    _assert_running(docker_client, r1)
+
+
+def test_remove_stopped_containers(docker_client, container_factory):
+
+    _assert_no_containers(docker_client)
+
+    c1 =container_factory.make_created()
+    r1 = container_factory.make_running()
+    s1 = container_factory.make_stopped()
+    s2 = container_factory.make_stopped()
+    _assert_existing(docker_client, c1, r1, s1, s2)
+    _assert_running(docker_client, r1)
+
+    main(['containers', '--exited', '0h',])
+
+    _assert_existing(docker_client, c1, r1)
+    _assert_running(docker_client, r1)
+
+
+def test_remove_non_running_containers(docker_client, container_factory):
+
+    _assert_no_containers(docker_client)
+
+    c1 = container_factory.make_created()
+    r1 = container_factory.make_running()
+    r2 = container_factory.make_running()
+    s1 = container_factory.make_stopped()
+    s2 = container_factory.make_stopped()
+    s3 = container_factory.make_stopped()
+    _assert_existing(docker_client, c1, r1, r2, s1, s2, s3)
+    _assert_running(docker_client, r1, r2)
+
+    main(['containers', '--created', '0h', '--exited', '0h'])
+
+    _assert_existing(docker_client, r1, r2)
+    _assert_running(docker_client, r1, r2)
+
+
+def test_dry_run(docker_client, container_factory):
+
+    _assert_no_containers(docker_client)
+
+    c1 = container_factory.make_created()
+    r1 = container_factory.make_running()
+    s1 = container_factory.make_stopped()
+    _assert_existing(docker_client, c1, r1, s1)
+    _assert_running(docker_client, r1)
+
+    main(['--dry-run', 'containers', '--created', '0h', '--exited', '0h'])
+
+    _assert_existing(docker_client, c1, r1, s1)
+    _assert_running(docker_client, r1)
+
+
+def test_time_exclusion(docker_client, container_factory):
+
+    _assert_no_containers(docker_client)
+
+    c1 = container_factory.make_created()
+    r1 = container_factory.make_running()
+    s1 = container_factory.make_stopped()
+    _assert_existing(docker_client, c1, r1, s1)
+    _assert_running(docker_client, r1)
+
+    main(['containers', '--created', '5m', '--exited', '5m'])
+
+    _assert_existing(docker_client, c1, r1, s1)
+    _assert_running(docker_client, r1)
+
+
+def test_name_matching(docker_client, container_factory):
+
+    CONTAINER_TEST_IMAGE_MATCH_NAME = 'locationlabs/zzzdockertestimage_for_container_matching'
+
+    _assert_no_containers(docker_client)
+
+    container_factory.image_factory.add_named(CONTAINER_TEST_IMAGE_MATCH_NAME, 'latest')
+
+    c1 = container_factory.make_created()
+    r1 = container_factory.make_running()
+    s1 = container_factory.make_stopped()
+    nc1 = container_factory.make_created(CONTAINER_TEST_IMAGE_MATCH_NAME)
+    nr1 = container_factory.make_running(CONTAINER_TEST_IMAGE_MATCH_NAME)
+    ns1 = container_factory.make_stopped(CONTAINER_TEST_IMAGE_MATCH_NAME)
+
+    _assert_existing(docker_client, c1, r1, s1, nc1, nr1, ns1)
+    _assert_running(docker_client, r1, nr1)
+
+    main(['containers', '--created', '0m', '--exited', '0m', '--images', CONTAINER_TEST_IMAGE_MATCH_NAME])
+
+    _assert_existing(docker_client, c1, r1, s1, nr1)
+    _assert_running(docker_client, r1, nr1)
+
+
+def test_inverse_name_matching(docker_client, container_factory):
+
+    CONTAINER_TEST_IMAGE_MATCH_NAME = 'locationlabs/zzzdockertestimage_for_container_matching'
+
+    _assert_no_containers(docker_client)
+
+    container_factory.image_factory.add_named(CONTAINER_TEST_IMAGE_MATCH_NAME, 'latest')
+
+    c1 = container_factory.make_created()
+    r1 = container_factory.make_running()
+    s1 = container_factory.make_stopped()
+    nc1 = container_factory.make_created(CONTAINER_TEST_IMAGE_MATCH_NAME)
+    nr1 = container_factory.make_running(CONTAINER_TEST_IMAGE_MATCH_NAME)
+    ns1 = container_factory.make_stopped(CONTAINER_TEST_IMAGE_MATCH_NAME)
+    _assert_existing(docker_client, c1, r1, s1, nc1, nr1, ns1)
+    _assert_running(docker_client, r1, nr1)
+
+    main(['containers', '--created', '0m', '--exited', '0m', '--images', "~" + CONTAINER_TEST_IMAGE_MATCH_NAME])
+
+    _assert_existing(docker_client, r1, nc1, nr1, ns1)
+    _assert_running(docker_client, r1, nr1)
+
+
+def test_label_matching(docker_client, container_factory):
+
+    LABEL = 'other_label'
+
+    _assert_no_containers(docker_client)
+
+    container_factory.image_factory.add(LABEL)
+    image_specifier = '{}:{}'.format(container_factory.image_factory.name, LABEL)
+
+    # create containers with the "latest" label and without
+    c1 = container_factory.make_created()
+    r1 = container_factory.make_running()
+    s1 = container_factory.make_stopped()
+    lc1 = container_factory.make_created(image_specifier)
+    lr1 = container_factory.make_running(image_specifier)
+    ls1 = container_factory.make_stopped(image_specifier)
+
+    _assert_existing(docker_client, c1, r1, s1, lc1, lr1, ls1)
+    _assert_running(docker_client, r1, lr1)
+
+    # clean up containers that are not using the latest image
+    main(['containers', '--created', '0m', '--exited', '0m', '--images', "~:other_label"])
+
+    _assert_existing(docker_client, r1, lc1, lr1, ls1)
+    _assert_running(docker_client, r1, lr1)
+

--- a/integration_test/test_images.py
+++ b/integration_test/test_images.py
@@ -1,0 +1,145 @@
+from dockerrotate.main import main
+
+import pytest
+
+
+def test_no_images_removed(docker_client):
+    # clean up images once
+    main(['--use-env', 'images', '--keep', '5'])
+
+    # get number of images
+    count = len(docker_client.images(all=False))
+
+    # clean up images again
+    main(['--use-env', 'images', '--keep', '5'])
+
+    updated_count = len(docker_client.images(all=False))
+
+    assert updated_count == count
+
+
+def test_remove_image(docker_client, image_factory):
+    # clean up images once
+    main(['--use-env', 'images', '--keep', '5'])
+
+    initial_count = len(docker_client.images(all=False))
+
+    for i in range(6):
+        image_factory.add('image_{}'.format(i), 'latest')
+
+    post_creation_count = len(docker_client.images())
+
+    assert post_creation_count == initial_count + 6
+
+    # clean up images again
+    main(['--use-env', 'images', '--keep', '5'])
+
+    final_count = len(docker_client.images())
+
+    assert final_count == post_creation_count - 1
+
+
+OTHER_TEST_IMAGE_NAME = 'locationlabs/zzzdockergentest_otherimage'
+
+
+def _images_with_name(docker_client, image_name):
+    return [ image for image in docker_client.images()
+             if any(tag.startswith(image_name + ":") for tag in image["RepoTags"])]
+
+
+def test_remove_only_matching(docker_client, image_factory):
+
+    to_create = 5
+    to_keep = 2
+
+    initial_count = len(docker_client.images())
+
+    for i in range(to_create):
+        image_factory.add('image_{}'.format(i), 'latest')
+        image_factory.add_named(OTHER_TEST_IMAGE_NAME, 'image_{}'.format(i), 'latest')
+
+    post_creation_count = len(docker_client.images())
+    assert post_creation_count == initial_count + to_create + to_create
+
+    # clean up images
+    main(['--use-env', 'images', '--keep', str(to_keep), '--images', OTHER_TEST_IMAGE_NAME])
+
+    # check that we cleaned up just the ones we care about.
+    matching_images = _images_with_name(docker_client, OTHER_TEST_IMAGE_NAME)
+    assert len(matching_images) == to_keep
+
+    # check no other images were cleaned
+    final_count = len(docker_client.images())
+    assert final_count == post_creation_count - (to_create - to_keep)
+
+
+def test_skip_removing_old_latest(docker_client, image_factory):
+
+    to_create = 5
+    to_keep = 2
+
+    initial_count = len(docker_client.images())
+
+    # oldest image is latest
+    image_factory.add('image_0', 'latest')
+    for i in range(1, to_create):
+        image_factory.add('image_{}'.format(i))
+
+    post_creation_count = len(docker_client.images())
+    assert post_creation_count == initial_count + to_create
+
+    # clean up images, but leave latest
+    main(['--use-env', 'images', '--keep', str(to_keep), '--images', image_factory.name, '~:latest'])
+
+    # check that we still have the right number, plus the latest
+    matching_images = _images_with_name(docker_client, image_factory.name)
+    assert len(matching_images) == to_keep + 1
+
+    # check that latest is still in there
+    latest_tag = "{}:latest".format(image_factory.name)
+    assert any(True for image in matching_images if latest_tag in image["RepoTags"])
+
+    # check no other images were cleaned
+    final_count = len(docker_client.images())
+    assert final_count == post_creation_count - (to_create - to_keep - 1)
+
+
+def test_skip_removing_new_latest(docker_client, image_factory):
+
+    to_create = 5
+    to_keep = 2
+
+    initial_count = len(docker_client.images())
+
+    # normal situation, where newest image is latest
+    for i in range(to_create):
+        image_factory.add('image_{}'.format(i), 'latest')
+
+    post_creation_count = len(docker_client.images())
+    assert post_creation_count == initial_count + to_create
+
+    print "all images for test_skip_removing_new_latest"
+    for image in docker_client.images():
+        print image["Id"], image["RepoTags"]
+    # clean up images, but leave latest
+    main(['--use-env', 'images', '--keep', str(to_keep), '--images', image_factory.name, '~:latest'])
+
+    # check that we still have two, plus the latest
+    matching_images = _images_with_name(docker_client, image_factory.name)
+    print "matching images for test_skip_removing_new_latest"
+    for image in matching_images:
+        print image["Id"], image["RepoTags"]
+    assert len(matching_images) == to_keep + 1
+
+    # check that latest is still in there
+    latest_tag = "{}:latest".format(image_factory.name)
+    assert any(True for image in matching_images if latest_tag in image["RepoTags"])
+
+    # check no other images were cleaned
+    final_count = len(docker_client.images())
+    assert final_count == post_creation_count - (to_create - to_keep - 1)
+
+
+
+
+

--- a/integration_test/test_images.py
+++ b/integration_test/test_images.py
@@ -1,145 +1,120 @@
-from dockerrotate.main import main
-
+import time
 import pytest
 
+from dockerrotate.main import main
+from imagetools import BASE_IMAGE, assert_images
 
-def test_no_images_removed(docker_client):
-    # clean up images once
-    main(['--use-env', 'images', '--keep', '5'])
 
-    # get number of images
-    count = len(docker_client.images(all=False))
+def test_no_images_removed(docker_client, image_factory):
 
-    # clean up images again
-    main(['--use-env', 'images', '--keep', '5'])
+    assert_images(docker_client)
+    id1 = image_factory.add('image_1', 'latest')
+    id2 = image_factory.add('image_2', 'latest')
 
-    updated_count = len(docker_client.images(all=False))
+    main(['images', '--keep', '3'])
+    assert_images(docker_client, id1, id2)
 
-    assert updated_count == count
+
+def test_no_images_removed_exactly(docker_client, image_factory):
+
+    assert_images(docker_client)
+    id1 = image_factory.add('image_1', 'latest')
+    id2 = image_factory.add('image_2', 'latest')
+
+    main(['images', '--keep', '2'])
+    assert_images(docker_client, id1, id2)
 
 
 def test_remove_image(docker_client, image_factory):
-    # clean up images once
-    main(['--use-env', 'images', '--keep', '5'])
+    assert_images(docker_client)
+    id1 = image_factory.add('image_1', 'latest')
+    id2 = image_factory.add('image_2', 'latest')
+    id3 = image_factory.add('image_3', 'latest')
+    id4 = image_factory.add('image_4', 'latest')
+    assert_images(docker_client, id1, id2, id3, id4)
 
-    initial_count = len(docker_client.images(all=False))
-
-    for i in range(6):
-        image_factory.add('image_{}'.format(i), 'latest')
-
-    post_creation_count = len(docker_client.images())
-
-    assert post_creation_count == initial_count + 6
-
-    # clean up images again
-    main(['--use-env', 'images', '--keep', '5'])
-
-    final_count = len(docker_client.images())
-
-    assert final_count == post_creation_count - 1
+    main(['images', '--keep', '2'])
+    assert_images(docker_client, id3, id4)
 
 
 OTHER_TEST_IMAGE_NAME = 'locationlabs/zzzdockergentest_otherimage'
 
 
-def _images_with_name(docker_client, image_name):
-    return [ image for image in docker_client.images()
-             if any(tag.startswith(image_name + ":") for tag in image["RepoTags"])]
-
-
 def test_remove_only_matching(docker_client, image_factory):
 
-    to_create = 5
-    to_keep = 2
+    assert_images(docker_client)
+    id1 = image_factory.add('image_1', 'latest')
+    id2 = image_factory.add('image_2', 'latest')
+    id3 = image_factory.add('image_3', 'latest')
+    id4 = image_factory.add('image_4', 'latest')
+    oid1 = image_factory.add_named(OTHER_TEST_IMAGE_NAME, 'image_1', 'latest')
+    oid2 = image_factory.add_named(OTHER_TEST_IMAGE_NAME, 'image_2', 'latest')
+    oid3 = image_factory.add_named(OTHER_TEST_IMAGE_NAME, 'image_3', 'latest')
+    oid4 = image_factory.add_named(OTHER_TEST_IMAGE_NAME, 'image_4', 'latest')
+    assert_images(docker_client, id1, id2, id3, id4, oid1, oid2, oid3, oid4)
 
-    initial_count = len(docker_client.images())
+    # dump images
+    print "dumping all images before delete"
+    for image in docker_client.images():
+        print " - id {}, tag0 {}, created {}".format(image["Id"], image["RepoTags"][0], image["Created"])
 
-    for i in range(to_create):
-        image_factory.add('image_{}'.format(i), 'latest')
-        image_factory.add_named(OTHER_TEST_IMAGE_NAME, 'image_{}'.format(i), 'latest')
+    main(['images', '--keep', '2', '--name', OTHER_TEST_IMAGE_NAME])
 
-    post_creation_count = len(docker_client.images())
-    assert post_creation_count == initial_count + to_create + to_create
-
-    # clean up images
-    main(['--use-env', 'images', '--keep', str(to_keep), '--images', OTHER_TEST_IMAGE_NAME])
-
-    # check that we cleaned up just the ones we care about.
-    matching_images = _images_with_name(docker_client, OTHER_TEST_IMAGE_NAME)
-    assert len(matching_images) == to_keep
-
-    # check no other images were cleaned
-    final_count = len(docker_client.images())
-    assert final_count == post_creation_count - (to_create - to_keep)
+    assert_images(docker_client, id1, id2, id3, id4, oid3, oid4)
 
 
 def test_skip_removing_old_latest(docker_client, image_factory):
 
-    to_create = 5
-    to_keep = 2
+    assert_images(docker_client)
+    id1 = image_factory.add('image_1', 'latest')
+    id2 = image_factory.add('image_2')
+    id3 = image_factory.add('image_3')
+    id4 = image_factory.add('image_4')
+    assert_images(docker_client, id1, id2, id3, id4)
 
-    initial_count = len(docker_client.images())
-
-    # oldest image is latest
-    image_factory.add('image_0', 'latest')
-    for i in range(1, to_create):
-        image_factory.add('image_{}'.format(i))
-
-    post_creation_count = len(docker_client.images())
-    assert post_creation_count == initial_count + to_create
+    # dump images
+    print "dumping all images before delete"
+    for image in docker_client.images():
+        print " - id {}, tag0 {}, created {}".format(image["Id"], image["RepoTags"][0], image["Created"])
 
     # clean up images, but leave latest
-    main(['--use-env', 'images', '--keep', str(to_keep), '--images', image_factory.name, '~:latest'])
+    main(['images', '--keep', '2', '--name', image_factory.name, '--tag', '~latest'])
 
-    # check that we still have the right number, plus the latest
-    matching_images = _images_with_name(docker_client, image_factory.name)
-    assert len(matching_images) == to_keep + 1
-
-    # check that latest is still in there
-    latest_tag = "{}:latest".format(image_factory.name)
-    assert any(True for image in matching_images if latest_tag in image["RepoTags"])
-
-    # check no other images were cleaned
-    final_count = len(docker_client.images())
-    assert final_count == post_creation_count - (to_create - to_keep - 1)
+    # check that we have the most recent two plus "latest"
+    assert_images(docker_client, id1, id3, id4)
 
 
 def test_skip_removing_new_latest(docker_client, image_factory):
 
-    to_create = 5
-    to_keep = 2
+    assert_images(docker_client)
+    id1 = image_factory.add('image_1')
+    id2 = image_factory.add('image_2')
+    id3 = image_factory.add('image_3')
+    id4 = image_factory.add('image_4', 'latest')
+    assert_images(docker_client, id1, id2, id3, id4)
 
-    initial_count = len(docker_client.images())
-
-    # normal situation, where newest image is latest
-    for i in range(to_create):
-        image_factory.add('image_{}'.format(i), 'latest')
-
-    post_creation_count = len(docker_client.images())
-    assert post_creation_count == initial_count + to_create
-
-    print "all images for test_skip_removing_new_latest"
-    for image in docker_client.images():
-        print image["Id"], image["RepoTags"]
     # clean up images, but leave latest
-    main(['--use-env', 'images', '--keep', str(to_keep), '--images', image_factory.name, '~:latest'])
+    main(['images', '--keep', '2', '--name', image_factory.name, '--tag', '~latest'])
 
-    # check that we still have two, plus the latest
-    matching_images = _images_with_name(docker_client, image_factory.name)
-    print "matching images for test_skip_removing_new_latest"
-    for image in matching_images:
-        print image["Id"], image["RepoTags"]
-    assert len(matching_images) == to_keep + 1
-
-    # check that latest is still in there
-    latest_tag = "{}:latest".format(image_factory.name)
-    assert any(True for image in matching_images if latest_tag in image["RepoTags"])
-
-    # check no other images were cleaned
-    final_count = len(docker_client.images())
-    assert final_count == post_creation_count - (to_create - to_keep - 1)
+    # check that we have just the most recent two
+    assert_images(docker_client, id3, id4)
 
 
+def test_skip_removing_in_use(docker_client, container_factory):
+    # container factory creates an image when created.
+    id1 = container_factory.image_id
 
+    # create a container that uses that image
+    cid1 = container_factory.make_created()
+
+    # create a couple of new images with the same factory
+    id2 = container_factory.image_factory.add("another_image", "latest")
+    id3 = container_factory.image_factory.add("yet_another_image", "latest")
+
+    # clean up images
+    main(['images', '--keep', '1'])
+
+    # original should still be there, and most recent, but middle image should be gone.
+    assert_images(docker_client, id1, id3)
 
 

--- a/integration_test/test_untagged.py
+++ b/integration_test/test_untagged.py
@@ -1,0 +1,51 @@
+from dockerrotate.main import main
+from imagetools import assert_images
+
+def test_untagged_null_case(docker_client):
+    # verify we have no images to start with
+    assert_images(docker_client)
+
+    # Run main and verify it doesn't fail
+    main(['untagged-images'])
+
+
+def test_untagged(docker_client, image_factory):
+    # add an image, then a second image with the same tag
+    # the first image will remain, but untagged.
+    id1 = image_factory.add('some_tag')
+    id2 = image_factory.add('some_tag')
+    assert_images(docker_client, id1, id2)
+
+    main(['untagged-images'])
+
+    # verify that the untagged image was removed
+    assert_images(docker_client, id2)
+
+
+def test_image_in_use(docker_client, container_factory):
+
+    # container factory creates an image when created.
+    id1 = container_factory.image_id
+
+    # create a container that uses that image
+    cid1 = container_factory.make_created()
+
+    # create a new image with the same factory and the same tags, to make the old image untagged
+    id2 = container_factory.image_factory.add(container_factory.IMAGE_TAG, "latest")
+
+    assert_images(docker_client, id1, id2)
+
+    import json
+    print "here are the containers at this point"
+    for container in docker_client.containers(all=True):
+        print json.dumps(container, indent=3)
+
+    main(['untagged-images'])
+
+    # verify that the untagged image was not removed
+    assert_images(docker_client, id1, id2)
+
+
+
+
+

--- a/run_vagrant_integration_tests.sh
+++ b/run_vagrant_integration_tests.sh
@@ -14,6 +14,9 @@ vagrant ssh vagrant-test-docker19 -c 'DOCKER_PY_VERSION="==1.7.0" /source/vagran
 echo "--------- Running tests on docker 1.11"
 vagrant ssh vagrant-test-docker111 -c 'DOCKER_PY_VERSION="==1.9.0" /source/vagrant/test.sh'
 
+echo "--------- Running tests on docker 1.12"
+vagrant ssh vagrant-test-docker112 -c 'DOCKER_PY_VERSION="==1.9.0" /source/vagrant/test.sh'
+
 echo "all tests complete, tearing down vagrant env"
 
 vagrant destroy

--- a/run_vagrant_integration_tests.sh
+++ b/run_vagrant_integration_tests.sh
@@ -3,10 +3,37 @@
 # fail if anything fails.
 set -e
 
+function usage() {
+   echo "Usage:"
+   echo ""
+   echo "    $0 -h"
+   echo "        show this message"
+   echo ""
+   echo "    $0"
+   echo "        run tests and clean up vagrant environment at the end"
+   echo ""
+   echo "    $0 --keep"
+   echo "        run tests and keep vagrant environment at the end"
+}
+
+if [ "$1" == "-h" ] || [ "$1" == "-?" ] || [ "$1" == "--help" ]; then
+   usage
+   exit 0
+elif [ "$1" == "--keep" ] ; then
+   keep_virts=yes
+elif [ "$1" != "" ] ; then
+   echo "Unrecognized option: $1"
+   usage
+   exit 1
+else
+   keep_virts=no
+fi
+
 echo "--------- Bringing up vagrant boxes"
 vagrant up
 
-# Current version of the library no longer supports Docker 1.5.0
+# Current version of docker-rotate library no longer supports Docker 1.5.0, otherwise
+# we'd want to test there too.
 
 echo "--------- Running tests on docker 1.9"
 vagrant ssh vagrant-test-docker19 -c 'DOCKER_PY_VERSION="==1.7.0" /source/vagrant/test.sh'
@@ -17,6 +44,10 @@ vagrant ssh vagrant-test-docker111 -c 'DOCKER_PY_VERSION="==1.9.0" /source/vagra
 echo "--------- Running tests on docker 1.12"
 vagrant ssh vagrant-test-docker112 -c 'DOCKER_PY_VERSION="==1.9.0" /source/vagrant/test.sh'
 
-echo "all tests complete, tearing down vagrant env"
-
-vagrant destroy
+if [ "$keep_virts" == "yes" ] ; then
+   echo "--------- all tests complete, skipping vagrant env cleanup"
+   echo "to clean up the VMs, run \"vagrant destroy\" from this directory."
+else 
+   echo "--------- all tests complete, tearing down vagrant env"
+   vagrant destroy -f
+fi

--- a/run_vagrant_integration_tests.sh
+++ b/run_vagrant_integration_tests.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# fail if anything fails.
+set -e
+
+echo "--------- Bringing up vagrant boxes"
+vagrant up
+
+# Current version of the library no longer supports Docker 1.5.0
+
+echo "--------- Running tests on docker 1.9"
+vagrant ssh vagrant-test-docker19 -c 'DOCKER_PY_VERSION="==1.7.0" /source/vagrant/test.sh'
+
+echo "--------- Running tests on docker 1.11"
+vagrant ssh vagrant-test-docker111 -c 'DOCKER_PY_VERSION="==1.9.0" /source/vagrant/test.sh'
+
+echo "all tests complete, tearing down vagrant env"
+
+vagrant destroy

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-__version__ = '2.0.1'
+__version__ = '3.0'
 
 __build__ = ''
 

--- a/setup.py
+++ b/setup.py
@@ -13,18 +13,10 @@ setup(name='dockerrotate',
       author_email='info@locationlabs.com',
       url='http://locationlabs.com',
       packages=find_packages(exclude=['*.tests']),
-      setup_requires=[
-          'nose>=1.3.7',
-      ],
       install_requires=[
           'docker-py>=1.6.0',
           'python-dateutil>=2.4.0',
       ],
-      tests_require=[
-          'mock',
-          'coverage',
-      ],
-      test_suite='dockerrotate.tests',
       entry_points={
           'console_scripts': [
               'docker-rotate = dockerrotate.main:main',

--- a/tests/test_argparse.py
+++ b/tests/test_argparse.py
@@ -1,0 +1,12 @@
+from datetime import timedelta
+
+from dockerrotate.main import parse_arguments
+
+
+def test_timestamp_parsing():
+
+    assert parse_arguments(['containers', '--created', '1h']).created == timedelta(hours=1)
+    assert parse_arguments(['containers', '--created', '23m']).created == timedelta(minutes=23)
+    assert parse_arguments(['containers', '--created', '2d']).created == timedelta(days=2)
+    assert parse_arguments(['containers', '--created', '0h']).created == timedelta()
+    assert parse_arguments(['containers', '--created', '0']).created == timedelta()

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -1,0 +1,94 @@
+from docker import Client
+from mock import create_autospec
+
+from dockerrotate.containers import determine_containers_to_remove
+from dockerrotate.main import parse_arguments
+from utils import created_container_entry, exited_container_entry, \
+                  dead_container_entry, running_container_entry, mins_ago, \
+                  containers_result
+
+
+IID = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb01"
+
+CID1 = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc01"
+CID2 = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc02"
+CID3 = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc03"
+CID4 = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc04"
+CID5 = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc05"
+CID6 = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc06"
+
+
+def _assert_ids(containers, *container_ids):
+    assert set(container["Id"] for container in containers) == set(container_ids)
+
+    # make sure there aren't repeats in the list to delete, too.
+    assert len(containers) == len(container_ids)
+
+
+def _mock_containers(containers, args):
+    mock_client = create_autospec(Client)
+    mock_client.containers.return_value = containers_result(containers)
+    lookup = {container["Id"]: container for container in containers}
+
+    mock_client.inspect_container.side_effect = lambda container_id: lookup[container_id]
+    args.client = mock_client
+
+
+def test_created():
+    containers = [
+        created_container_entry(CID1, IID, mins_ago(2465)),
+        created_container_entry(CID2, IID, mins_ago(61)),
+        created_container_entry(CID3, IID, mins_ago(25)),
+        running_container_entry(CID4, IID, mins_ago(2465)),
+        exited_container_entry(CID5, IID, mins_ago(2001)),
+        dead_container_entry(CID6, IID, mins_ago(2011))
+    ]
+    args = parse_arguments(['containers', '--created', '1h'])
+    _mock_containers(containers, args)
+    result = determine_containers_to_remove(args)
+    _assert_ids(result, CID1, CID2)
+
+
+def test_created_zero_timestamp():
+    containers = [
+        created_container_entry(CID1, IID, mins_ago(2465)),
+        created_container_entry(CID2, IID, mins_ago(61)),
+        created_container_entry(CID3, IID, mins_ago(25)),
+        running_container_entry(CID4, IID, mins_ago(2465)),
+        exited_container_entry(CID5, IID, mins_ago(2001)),
+        dead_container_entry(CID6, IID, mins_ago(2011))
+    ]
+    args = parse_arguments(['containers', '--created', '0'])
+    _mock_containers(containers, args)
+    result = determine_containers_to_remove(args)
+    _assert_ids(result, CID1, CID2, CID3)
+
+
+def test_exited():
+    containers = [
+        exited_container_entry(CID1, IID, mins_ago(2465)),
+        exited_container_entry(CID2, IID, mins_ago(61)),
+        exited_container_entry(CID3, IID, mins_ago(25)),
+        running_container_entry(CID4, IID, mins_ago(2465)),
+        created_container_entry(CID5, IID, mins_ago(2001)),
+        dead_container_entry(CID6, IID, mins_ago(2011))
+    ]
+    args = parse_arguments(['containers', '--exited', '1h'])
+    _mock_containers(containers, args)
+    result = determine_containers_to_remove(args)
+    _assert_ids(result, CID1, CID2)
+
+
+def test_dead():
+    containers = [
+        dead_container_entry(CID1, IID, mins_ago(2465)),
+        dead_container_entry(CID2, IID, mins_ago(61)),
+        dead_container_entry(CID3, IID, mins_ago(25)),
+        running_container_entry(CID4, IID, mins_ago(2465)),
+        created_container_entry(CID5, IID, mins_ago(2001)),
+        exited_container_entry(CID6, IID, mins_ago(2011))
+    ]
+    args = parse_arguments(['containers', '--dead', '1h'])
+    _mock_containers(containers, args)
+    result = determine_containers_to_remove(args)
+    _assert_ids(result, CID1, CID2)

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -1,0 +1,182 @@
+import pytest
+
+from dockerrotate.images import determine_images_to_remove, find_image_ids_to_keep
+from dockerrotate.main import parse_arguments
+
+from utils import image_entry, created_container_entry, containers_result, mins_ago
+
+
+IID1 = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb01"
+IID2 = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb02"
+IID3 = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb03"
+IID4 = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb04"
+IID5 = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb05"
+IID6 = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb06"
+IID7 = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb07"
+
+CID1 = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc01"
+CID2 = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc02"
+CID3 = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc03"
+CID4 = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc04"
+CID5 = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc05"
+CID6 = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc06"
+
+
+def _assert_ids(images, *image_ids):
+    assert set(image["Id"] for image in images) == set(image_ids)
+
+    # make sure there aren't repeats in the list to delete, too.
+    assert len(images) == len(image_ids)
+
+
+def test_keep_two():
+    images = [
+        image_entry(IID1, mins_ago(200), "foo:v1.1"),
+        image_entry(IID2, mins_ago(190), "foo:v1.2"),
+        image_entry(IID3, mins_ago(180), "foo:v1.3"),
+        image_entry(IID4, mins_ago(170), "foo:v1.4", "foo:latest"),
+    ]
+    args = parse_arguments(['images', '--keep', '2'])
+    result = determine_images_to_remove(images, [], args)
+    _assert_ids(result, IID1, IID2)
+
+
+def test_keep_zero():
+    images = [
+        image_entry(IID1, mins_ago(200), "foo:v1.1"),
+        image_entry(IID2, mins_ago(190), "foo:v1.2"),
+        image_entry(IID3, mins_ago(180), "foo:v1.3"),
+        image_entry(IID4, mins_ago(170), "foo:v1.4", "foo:latest"),
+    ]
+    args = parse_arguments(['images', '--keep', '0'])
+
+    ids_to_keep = find_image_ids_to_keep(images, args)
+    assert ids_to_keep == set()
+
+    result = determine_images_to_remove(images, [], args)
+    _assert_ids(result, IID1, IID2, IID3, IID4)
+
+
+def test_keep_with_active():
+    images = [
+        image_entry(IID1, mins_ago(200), "foo:v1.1"),
+        image_entry(IID2, mins_ago(190), "foo:v1.2"),
+        image_entry(IID3, mins_ago(180), "foo:v1.3"),
+        image_entry(IID4, mins_ago(170), "foo:v1.4", "foo:latest"),
+    ]
+    containers = [
+        created_container_entry(CID1, IID2, mins_ago(5)),
+        created_container_entry(CID2, IID3, mins_ago(5))]
+    args = parse_arguments(['images', '--keep', '2'])
+    result = determine_images_to_remove(images, containers_result(containers), args)
+    _assert_ids(result, IID1)
+
+
+def test_keep_with_active_and_filter():
+    images = [
+        image_entry(IID1, mins_ago(200), "foo:v1.1"),
+        image_entry(IID2, mins_ago(190), "foo:v1.2"),
+        image_entry(IID3, mins_ago(180), "foo:v1.3"),
+        image_entry(IID4, mins_ago(170), "foo:v1.4", "foo:latest"),
+    ]
+    containers = [
+        created_container_entry(CID1, IID2, mins_ago(5)),
+        created_container_entry(CID2, IID3, mins_ago(5))]
+    args = parse_arguments(['images', '--keep', '2', '--name', 'foo'])
+    result = determine_images_to_remove(images, containers_result(containers), args)
+    _assert_ids(result, IID1)
+
+
+def test_keep_multiname():
+    images = [
+        image_entry(IID1, mins_ago(200), "foo:v1.1", "bar:v1"),
+        image_entry(IID2, mins_ago(190), "foo:v1.2"),
+        image_entry(IID3, mins_ago(180), "foo:v1.3"),
+        image_entry(IID4, mins_ago(170), "foo:v1.4"),
+    ]
+    args = parse_arguments(['images', '--keep', '2'])
+    result = determine_images_to_remove(images, [], args)
+    _assert_ids(result, IID2)
+
+
+def test_keep_multiname_with_filter():
+    """Even though we're only deleting records with name "foo", "keep" trumps filters"""
+    images = [
+        image_entry(IID1, mins_ago(200), "foo:v1.1", "bar:v1"),
+        image_entry(IID2, mins_ago(190), "foo:v1.2"),
+        image_entry(IID3, mins_ago(180), "foo:v1.3"),
+        image_entry(IID4, mins_ago(170), "foo:v1.4"),
+    ]
+    args = parse_arguments(['images', '--keep', '2', '--name', 'foo'])
+    result = determine_images_to_remove(images, [], args)
+    _assert_ids(result, IID2)
+
+
+def test_negative_tag_filter():
+    images = [
+        image_entry(IID1, mins_ago(200), "foo:v1.1", "foo:latest"),
+        image_entry(IID2, mins_ago(190), "foo:v1.2"),
+        image_entry(IID3, mins_ago(180), "foo:v1.3"),
+        image_entry(IID4, mins_ago(170), "foo:v1.4"),
+    ]
+    args = parse_arguments(['images', '--keep', '2', '--tag', '~latest'])
+    result = determine_images_to_remove(images, [], args)
+    _assert_ids(result, IID2)
+
+
+def test_negative_tag_on_different_name_filter():
+    images = [
+        image_entry(IID1, mins_ago(200), "foo:v1.1", "bar:latest"),
+        image_entry(IID2, mins_ago(190), "foo:v1.2"),
+        image_entry(IID3, mins_ago(180), "foo:v1.3"),
+        image_entry(IID4, mins_ago(170), "foo:v1.4"),
+    ]
+    args = parse_arguments(['images', '--keep', '2', '--tag', '~latest'])
+    result = determine_images_to_remove(images, [], args)
+    _assert_ids(result, IID2)
+
+
+def test_positive_name_filter():
+    images = [
+        image_entry(IID1, mins_ago(200), "somewhere.org/someorg/foo:v1.1"),
+        image_entry(IID2, mins_ago(190), "someorg/foo:v1.2"),
+        image_entry(IID3, mins_ago(180), "someorg/foo:v1.3"),
+        image_entry(IID4, mins_ago(210), "someorg/bar:R1"),
+        image_entry(IID4, mins_ago(195), "somewhere.org/someorg/bar:R2"),
+        image_entry(IID4, mins_ago(165), "someorg/bar:R3"),
+    ]
+    args = parse_arguments(['images', '--keep', '2', '--name', 'someorg/foo'])
+    result = determine_images_to_remove(images, [], args)
+    _assert_ids(result, IID1)
+
+
+def test_partial_name_doesnt_match():
+    images = [
+        image_entry(IID1, mins_ago(200), "somewhere.org/someorg/foo:v1.1"),
+        image_entry(IID2, mins_ago(190), "someorg/foo:v1.2"),
+        image_entry(IID3, mins_ago(180), "someorg/foo:v1.3"),
+        image_entry(IID4, mins_ago(210), "someorg/foo_monitor:R1"),
+        image_entry(IID4, mins_ago(195), "somewhere.org/someorg/foo_monitor:R2"),
+        image_entry(IID4, mins_ago(165), "someorg/foo_monitor:R3"),
+    ]
+    args = parse_arguments(['images', '--keep', '2', '--name', 'someorg/foo'])
+    result = determine_images_to_remove(images, [], args)
+    _assert_ids(result, IID1)
+
+
+def test_regexes():
+    images = [
+        # should be deleted
+        image_entry(IID1, mins_ago(200), "somewhere.org/someorg/foo:v1.1"),
+        image_entry(IID2, mins_ago(190), "someorg/foo:v1.2"),
+        # should be skipped
+        image_entry(IID3, mins_ago(190), "awesomeorg/foo:v1.2"),
+        image_entry(IID4, mins_ago(180), "someorg/notfoo:v1.3"),
+        image_entry(IID5, mins_ago(180), "someorg/Foo:v1.3"),
+        image_entry(IID6, mins_ago(180), "someorg/foo_nope:v1.3"),
+        image_entry(IID7, mins_ago(180), "someorg/nope/foo:v1.3"),
+    ]
+    args = parse_arguments(['images', '--keep', '0', '--name', 'someorg/[^/]*', '--name', '[^/]*/foo'])
+    result = determine_images_to_remove(images, [], args)
+    _assert_ids(result, IID1, IID2)
+

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,0 +1,7 @@
+from dockerrotate.images import normalize_tag_name
+
+def test_normalize_tag_name():
+
+    assert normalize_tag_name('some.domain.com/organization/image:tag') == 'organization/image'
+    assert normalize_tag_name('organization/image:tag') == 'organization/image'
+    assert normalize_tag_name('image:tag') == 'image'

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,95 @@
+"""
+This file contains utility classes and generators for use in tests.
+"""
+
+import datetime
+
+from dateutil.tz import tzutc
+
+NOW = datetime.datetime.now(tzutc())
+
+
+def mins_ago(minutes_ago):
+    return NOW - datetime.timedelta(minutes=minutes_ago)
+
+
+def _to_unixtime(dt):
+    return int(dt.strftime("%s"))
+
+
+def _to_timestamp(dt):
+    # should only be using this with UTC datetimes
+    assert dt.tzinfo == tzutc()
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+
+def image_entry(image_id, created, *repotags):
+    return dict(Id=image_id,
+                Created=_to_unixtime(created),
+                RepoTags=repotags)
+
+
+def exited_container_entry(container_id, image_id, timestamp):
+    return dict(Id=container_id,
+                Image=image_id,
+                State=dict(ExitCode=0,
+                           FinishedAt=_to_timestamp(timestamp),
+                           OOMKilled=False,
+                           Dead=False,
+                           Paused=False,
+                           Restarting=False,
+                           Running=False,
+                           Status="exited"))
+
+
+def created_container_entry(container_id, image_id, timestamp):
+    return dict(
+        Id=container_id,
+        Image=image_id,
+        Created=_to_timestamp(timestamp),
+        State=dict(OOMKilled=False,
+                   Dead=False,
+                   Paused=False,
+                   Restarting=False,
+                   Running=False,
+                   StartedAt=_to_timestamp(timestamp),
+                   Status="created"))
+
+
+def dead_container_entry(container_id, image_id, timestamp):
+    return dict(
+        Id=container_id,
+        Image=image_id,
+        State=dict(OOMKilled=False,
+                   Dead=True,
+                   Paused=False,
+                   Restarting=False,
+                   Running=False,
+                   FinishedAt=_to_timestamp(timestamp),
+                   Status="dead"))
+
+
+def running_container_entry(container_id, image_id, timestamp):
+    return dict(
+        Id=container_id,
+        Image=image_id,
+        Created=_to_timestamp(timestamp),
+        State=dict(OOMKilled=False,
+                   Dead=False,
+                   Paused=False,
+                   Restarting=False,
+                   Running=True,
+                   StartedAt=_to_timestamp(timestamp),
+                   Status="running"))
+
+
+def containers_result(containers):
+    """
+    Generates something that looks like of the result from the "docker.Client.containers()" call.
+    Unlike "docker.Client.images()", the result from "container()" is just a stub; full
+    information requires a call to "docker.Client.inspect_container()"
+    """
+    return [dict(Id=container["Id"],
+                 ImageID=container["Image"]) for container in containers]
+
+

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,11 @@ envlist = py27,lint
 [testenv]
 commands =
     python setup.py sdist
+    py.test tests {posargs}
 deps =
     setuptools>=17.1
+    pytest
+    mock
 
 [testenv:lint]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -3,14 +3,30 @@ envlist = py27,lint
 
 [testenv]
 commands =
-    python setup.py nosetests --with-coverage --cover-package=dockerrotate --cover-erase --cover-html
     python setup.py sdist
 deps =
     setuptools>=17.1
 
 [testenv:lint]
-commands=flake8 --max-line-length 99 dockerrotate
-basepython=python2.7
-deps=
+commands =
+    flake8 --max-line-length 99 dockerrotate
+basepython = python2.7
+deps =
     flake8
-    flake8-print
+
+# These are the integration tests. They make changes to your Docker environment, possibly permanent.
+# They are not included in the default environment list. To run them, run: 
+# "tox -e integration_test".
+[testenv:integration_test]
+deps =
+    pytest
+    docker-py{env:DOCKER_PY_VERSION:>=1.6.0}
+basepython = python2.7
+changedir = integration_test
+commands =
+    pip freeze
+    py.test -v {posargs}
+setenv = 
+   DOCKER_HOST={env:DOCKER_HOST:}
+   DOCKER_CERT_PATH={env:DOCKER_CERT_PATH:}
+   DOCKER_TLS_VERIFY={env:DOCKER_TLS_VERIFY:}

--- a/vagrant/setup_docker.sh
+++ b/vagrant/setup_docker.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Sets up Docker on a normal Ubuntu 14.04 host, based on the first command-line argument, which
+# specifies the Docker version
+
+# Make the HTTPS transport is available to APT
+if [ ! -e /usr/lib/apt/methods/https ]; then
+    apt-get update
+    apt-get install -y apt-transport-https
+fi
+
+DOCKER_VERSION=$1
+
+if [ "$DOCKER_VERSION" == "1.5.0" ] ; then
+   DOCKER_PACKAGE="lxc-docker-1.5.0"
+
+   apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 36A1D7869245C8950F966E92D8576A8BA88D21E9
+
+   echo deb https://get.docker.com/ubuntu docker main > /etc/apt/sources.list.d/docker.list
+else
+   DOCKER_PACKAGE="docker-engine=${DOCKER_VERSION}-0~trusty"
+
+   apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D
+
+   echo deb https://apt.dockerproject.org/repo ubuntu-trusty main > /etc/apt/sources.list.d/docker.list
+fi
+
+# Install docker and python
+apt-get update
+apt-get install -y $DOCKER_PACKAGE python-pip
+pip install --upgrade virtualenv tox pip
+adduser vagrant docker

--- a/vagrant/test.sh
+++ b/vagrant/test.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+rm -rf /tmp/source
+cp -r /source /tmp/
+cd /tmp/source
+tox -e integration_test "$@"


### PR DESCRIPTION
The API update here:
- makes the tool's behavior clearer (in the author's opinion) and more explicit.
- removes the unexpected default behavior in the 2.0 API, resolving issue #9 
- changes regexes to be full matches. (In 2.0, if you call the tool with "images --images myorg/foo", it will delete "myorg/foo_monitor" as well - not really the expected behavior!)
- adds the capability to clean up untagged images

The change request also:
- adds unit tests and integration tests.
- deals with logical issues when images have multiple names.

This pull request does drop support for image filtering when cleaning up containers. I don't think that behavior is widely used, and there were issues with the old implementation. (Specifically: it only looked at the "Image" field in the response from docker.Client.containers() when considering the image that was used to create a container; that field is based on just one of the current tags of the image. The image might have other tags, and it might have a completely different tag when the image was created.)
