### PR TITLE
Fill in missing fields for use with pre-1.21 API

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,4 +1,10 @@
 nodes = [
+  { :hostname => 'vagrant-test-docker15',
+    :ip => '172.16.218.2',
+    :box => 'bento/ubuntu-14.04',
+    :ram => 128,
+    :cpus => 1,
+    :docker_version => '1.5.0'},
   { :hostname => 'vagrant-test-docker19',
     :ip => '172.16.218.3',
     :box => 'bento/ubuntu-14.04',

--- a/dockerrotate/containers.py
+++ b/dockerrotate/containers.py
@@ -34,7 +34,8 @@ def inspect_container(container, args):
             "running" if inspect_data["State"]["Running"] else
             "paused" if inspect_data["State"]["Paused"] else
             "dead" if inspect_data["State"].get("Dead", False) else
-            "exited" if not inspect_data["State"]["Pid"] else
+            "exited" if (not inspect_data["State"]["Pid"]
+                         and inspect_data["State"]["StartedAt"] >= inspect_data["Created"]) else
             "created"
         )
     return inspect_data

--- a/dockerrotate/images.py
+++ b/dockerrotate/images.py
@@ -24,6 +24,7 @@ from collections import defaultdict
 
 from docker.errors import APIError
 
+from dockerrotate.containers import all_containers
 from dockerrotate.filter import regex_positive_match, regex_negative_match
 
 
@@ -98,7 +99,7 @@ def clean_images(args):
     # should not need to inspect all images; only intermediate images should appear
     # when all is true; these should be deleted along with dependent images
     images = args.client.images(all=False)
-    containers = args.client.containers(all=True)
+    containers = all_containers(args)
 
     images_to_remove = determine_images_to_remove(images, containers, args)
 

--- a/dockerrotate/untagged.py
+++ b/dockerrotate/untagged.py
@@ -10,13 +10,15 @@ here is smart enough not to try to delete images that are in use.)
 """
 from docker.errors import APIError
 
+from dockerrotate.containers import all_containers
+
 
 def _find_image_ids_in_use(containers):
     return set(container["ImageID"] for container in containers)
 
 
 def clean_untagged(args):
-    containers = args.client.containers(all=True)
+    containers = all_containers(args)
     untagged_images = args.client.images(filters=dict(dangling=True))
     image_ids_in_use = _find_image_ids_in_use(containers)
 

--- a/integration_test/conftest.py
+++ b/integration_test/conftest.py
@@ -5,13 +5,23 @@ from docker import Client
 from docker.utils import kwargs_from_env
 import pytest
 
+from dockerrotate.main import main as docker_rotate_main
 from imagetools import ImageFactory
 from containertools import ContainerFactory
 
 
+def pytest_addoption(parser):
+    parser.addoption("--client-version",
+                     help="Specify Docker client version to use.",
+                     default=None)
+
+
 @pytest.fixture(scope="module")
-def docker_client():
+def docker_client(pytestconfig):
     kwargs = kwargs_from_env(assert_hostname=False)
+    version = pytestconfig.getoption("--client-version")
+    if version is not None:
+        kwargs["version"] = version
     client = Client(**kwargs)
 
     # Verify client can talk to server.
@@ -19,6 +29,19 @@ def docker_client():
     client.version()
 
     return client
+
+
+@pytest.fixture
+def docker_rotate(pytestconfig):
+    """A wrapper around dockerrotate.main that injects --client-version when supplied."""
+    def _docker_rotate(args):
+        version = pytestconfig.getoption("--client-version")
+        if "--client-version" not in args and version is not None:
+            args = ["--client-version", version] + args
+
+        return docker_rotate_main(args)
+
+    return _docker_rotate
 
 
 @pytest.yield_fixture

--- a/integration_test/containertools.py
+++ b/integration_test/containertools.py
@@ -1,6 +1,7 @@
-import pytest
+import time
 
 from imagetools import ImageFactory
+
 
 class ContainerFactory:
     IMAGE_NAME = 'locationlabs/zzzdockertestimage_for_containers'

--- a/integration_test/containertools.py
+++ b/integration_test/containertools.py
@@ -39,8 +39,7 @@ class ContainerFactory:
         started = False
         for counter in range(100):
             info = self.docker_client.inspect_container(container_id)
-            state = info["State"]["Status"]
-            if state == "running":
+            if info["State"]["Running"]:
                 started = True
                 break
             time.sleep(0.2)

--- a/integration_test/imagetools.py
+++ b/integration_test/imagetools.py
@@ -4,7 +4,6 @@ import textwrap
 import time
 
 from docker.errors import NotFound
-import pytest
 
 
 DEFAULT_TEST_IMAGE_NAME = 'locationlabs/zzzdockertestimage'
@@ -13,7 +12,7 @@ BASE_IMAGE = "alpine:3.4"
 
 def _normalize_image_id(image_id):
     """
-    The image IDs we get back from parsing "docker build output are abbreviated, 12 hex digits long.
+    The image IDs we get back from parsing "docker build" output are abbreviated to 12 hex digits.
     In order to compare them to the ids we get from "docker.Client.images()" calls, we need to
     normalize them
     """
@@ -100,6 +99,3 @@ class ImageFactory:
             except NotFound:
                 pass
         return cleaned
-
-
-

--- a/integration_test/test_containers.py
+++ b/integration_test/test_containers.py
@@ -1,6 +1,3 @@
-from dockerrotate.main import main
-
-
 def _totals(docker_client):
     return (len(docker_client.containers()), len(docker_client.containers(all=True)))
 
@@ -20,7 +17,8 @@ def _assert_running(docker_client, *ids):
     existing_container_ids = set(container["Id"] for container in docker_client.containers())
     assert existing_container_ids == set(ids)
 
-def test_remove_created_containers(docker_client, container_factory):
+
+def test_remove_created_containers(docker_client, container_factory, docker_rotate):
 
     _assert_no_containers(docker_client)
 
@@ -37,7 +35,7 @@ def test_remove_created_containers(docker_client, container_factory):
     _assert_running(docker_client, r1)
 
 
-def test_remove_stopped_containers(docker_client, container_factory):
+def test_remove_stopped_containers(docker_client, container_factory, docker_rotate):
 
     _assert_no_containers(docker_client)
 
@@ -54,7 +52,7 @@ def test_remove_stopped_containers(docker_client, container_factory):
     _assert_running(docker_client, r1)
 
 
-def test_remove_non_running_containers(docker_client, container_factory):
+def test_remove_non_running_containers(docker_client, container_factory, docker_rotate):
 
     _assert_no_containers(docker_client)
 
@@ -67,13 +65,13 @@ def test_remove_non_running_containers(docker_client, container_factory):
     _assert_existing(docker_client, c1, r1, r2, s1, s2, s3)
     _assert_running(docker_client, r1, r2)
 
-    main(['containers', '--created', '0h', '--exited', '0h'])
+    docker_rotate(['containers', '--created', '0h', '--exited', '0h'])
 
     _assert_existing(docker_client, r1, r2)
     _assert_running(docker_client, r1, r2)
 
 
-def test_dry_run(docker_client, container_factory):
+def test_dry_run(docker_client, container_factory, docker_rotate):
 
     _assert_no_containers(docker_client)
 
@@ -83,13 +81,13 @@ def test_dry_run(docker_client, container_factory):
     _assert_existing(docker_client, c1, r1, s1)
     _assert_running(docker_client, r1)
 
-    main(['--dry-run', 'containers', '--created', '0h', '--exited', '0h'])
+    docker_rotate(['--dry-run', 'containers', '--created', '0h', '--exited', '0h'])
 
     _assert_existing(docker_client, c1, r1, s1)
     _assert_running(docker_client, r1)
 
 
-def test_time_exclusion(docker_client, container_factory):
+def test_time_exclusion(docker_client, container_factory, docker_rotate):
 
     _assert_no_containers(docker_client)
 
@@ -99,7 +97,7 @@ def test_time_exclusion(docker_client, container_factory):
     _assert_existing(docker_client, c1, r1, s1)
     _assert_running(docker_client, r1)
 
-    main(['containers', '--created', '5m', '--exited', '5m'])
+    docker_rotate(['containers', '--created', '5m', '--exited', '5m'])
 
     _assert_existing(docker_client, c1, r1, s1)
     _assert_running(docker_client, r1)
@@ -108,7 +106,7 @@ def test_time_exclusion(docker_client, container_factory):
 # Name and tag matching for containers was dropped as part of the 3.0 release.
 # If we add it back at some point, here are integration tests for it.
 #
-# def test_name_matching(docker_client, container_factory):
+# def test_name_matching(docker_client, container_factory, docker_rotate):
 #
 #     CONTAINER_TEST_IMAGE_MATCH_NAME = 'locationlabs/zzzdockertestimage_for_container_matching'
 #
@@ -133,7 +131,7 @@ def test_time_exclusion(docker_client, container_factory):
 #     _assert_running(docker_client, r1, nr1)
 #
 #
-# def test_inverse_name_matching(docker_client, container_factory):
+# def test_inverse_name_matching(docker_client, container_factory, docker_rotate):
 #
 #     CONTAINER_TEST_IMAGE_MATCH_NAME = 'locationlabs/zzzdockertestimage_for_container_matching'
 #
@@ -157,7 +155,7 @@ def test_time_exclusion(docker_client, container_factory):
 #     _assert_running(docker_client, r1, nr1)
 #
 #
-# def test_label_matching(docker_client, container_factory):
+# def test_label_matching(docker_client, container_factory, docker_rotate):
 #
 #     LABEL = 'other_label'
 #

--- a/integration_test/test_containers.py
+++ b/integration_test/test_containers.py
@@ -1,18 +1,20 @@
-import pytest
-
 from dockerrotate.main import main
 
 
 def _totals(docker_client):
     return (len(docker_client.containers()), len(docker_client.containers(all=True)))
 
+
 def _assert_no_containers(docker_client):
     # common precondition: no existing containers
     assert docker_client.containers(all=True) == []
 
+
 def _assert_existing(docker_client, *ids):
-    existing_container_ids = set(container["Id"] for container in docker_client.containers(all=True))
+    existing_container_ids = set(container["Id"] for container
+                                 in docker_client.containers(all=True))
     assert existing_container_ids == set(ids)
+
 
 def _assert_running(docker_client, *ids):
     existing_container_ids = set(container["Id"] for container in docker_client.containers())
@@ -23,13 +25,13 @@ def test_remove_created_containers(docker_client, container_factory):
     _assert_no_containers(docker_client)
 
     c1 = container_factory.make_created()
-    c2 =container_factory.make_created()
+    c2 = container_factory.make_created()
     r1 = container_factory.make_running()
     s1 = container_factory.make_stopped()
     _assert_existing(docker_client, c1, c2, r1, s1)
     _assert_running(docker_client, r1)
 
-    main(['containers', '--created', '0h',])
+    docker_rotate(['containers', '--created', '0h'])
 
     _assert_existing(docker_client, r1, s1)
     _assert_running(docker_client, r1)
@@ -39,14 +41,14 @@ def test_remove_stopped_containers(docker_client, container_factory):
 
     _assert_no_containers(docker_client)
 
-    c1 =container_factory.make_created()
+    c1 = container_factory.make_created()
     r1 = container_factory.make_running()
     s1 = container_factory.make_stopped()
     s2 = container_factory.make_stopped()
     _assert_existing(docker_client, c1, r1, s1, s2)
     _assert_running(docker_client, r1)
 
-    main(['containers', '--exited', '0h',])
+    docker_rotate(['containers', '--exited', '0h'])
 
     _assert_existing(docker_client, c1, r1)
     _assert_running(docker_client, r1)
@@ -124,7 +126,8 @@ def test_time_exclusion(docker_client, container_factory):
 #     _assert_existing(docker_client, c1, r1, s1, nc1, nr1, ns1)
 #     _assert_running(docker_client, r1, nr1)
 #
-#     main(['containers', '--created', '0m', '--exited', '0m', '--name', CONTAINER_TEST_IMAGE_MATCH_NAME])
+#     docker_rotate(['containers', '--created', '0m', '--exited', '0m', '--name',
+#                    CONTAINER_TEST_IMAGE_MATCH_NAME])
 #
 #     _assert_existing(docker_client, c1, r1, s1, nr1)
 #     _assert_running(docker_client, r1, nr1)
@@ -147,7 +150,8 @@ def test_time_exclusion(docker_client, container_factory):
 #     _assert_existing(docker_client, c1, r1, s1, nc1, nr1, ns1)
 #     _assert_running(docker_client, r1, nr1)
 #
-#     main(['containers', '--created', '0m', '--exited', '0m', '--name', "~" + CONTAINER_TEST_IMAGE_MATCH_NAME])
+#     docker_rotate(['containers', '--created', '0m', '--exited', '0m', '--name',
+#                    "~" + CONTAINER_TEST_IMAGE_MATCH_NAME])
 #
 #     _assert_existing(docker_client, r1, nc1, nr1, ns1)
 #     _assert_running(docker_client, r1, nr1)
@@ -174,8 +178,8 @@ def test_time_exclusion(docker_client, container_factory):
 #     _assert_running(docker_client, r1, lr1)
 #
 #     # clean up containers that are not using the latest image
-#     main(['containers', '--created', '0m', '--exited', '0m', '--images', "~:other_label"])
+#     docker_rotate(['containers', '--created', '0m', '--exited', '0m',
+#                    '--images', "~:other_label"])
 #
 #     _assert_existing(docker_client, r1, lc1, lr1, ls1)
 #     _assert_running(docker_client, r1, lr1)
-

--- a/integration_test/test_images.py
+++ b/integration_test/test_images.py
@@ -1,6 +1,3 @@
-import time
-import pytest
-
 from dockerrotate.main import main
 from imagetools import assert_images, ImageFactory
 
@@ -56,7 +53,8 @@ def test_remove_only_matching(docker_client, image_factory):
     # dump images
     print "dumping all images before delete"
     for image in docker_client.images():
-        print " - id {}, tag0 {}, created {}".format(image["Id"], image["RepoTags"][0], image["Created"])
+        print " - id {}, tag0 {}, created {}".format(
+            image["Id"], image["RepoTags"][0], image["Created"])
 
     main(['images', '--keep', '2', '--name', OTHER_TEST_IMAGE_NAME])
 
@@ -75,7 +73,8 @@ def test_skip_removing_old_latest(docker_client, image_factory):
     # dump images
     print "dumping all images before delete"
     for image in docker_client.images():
-        print " - id {}, tag0 {}, created {}".format(image["Id"], image["RepoTags"][0], image["Created"])
+        print " - id {}, tag0 {}, created {}".format(
+            image["Id"], image["RepoTags"][0], image["Created"])
 
     # clean up images, but leave latest
     main(['images', '--keep', '2', '--name', image_factory.name, '--tag', '~latest'])
@@ -105,10 +104,10 @@ def test_skip_removing_in_use(docker_client, container_factory):
     id1 = container_factory.image_id
 
     # create a container that uses that image
-    cid1 = container_factory.make_created()
+    container_factory.make_created()
 
     # create a couple of new images with the same factory
-    id2 = container_factory.image_factory.add("another_image", "latest")
+    container_factory.image_factory.add("another_image", "latest")
     id3 = container_factory.image_factory.add("yet_another_image", "latest")
 
     # clean up images
@@ -165,7 +164,3 @@ def test_remove_matching_image_extra_tag(docker_client, image_factory):
 
     finally:
         other_image_factory.cleanup()
-
-
-
-

--- a/integration_test/test_images.py
+++ b/integration_test/test_images.py
@@ -1,28 +1,27 @@
-from dockerrotate.main import main
 from imagetools import assert_images, ImageFactory
 
 
-def test_no_images_removed(docker_client, image_factory):
+def test_no_images_removed(docker_client, image_factory, docker_rotate):
 
     assert_images(docker_client)
     id1 = image_factory.add('image_1', 'latest')
     id2 = image_factory.add('image_2', 'latest')
 
-    main(['images', '--keep', '3'])
+    docker_rotate(['images', '--keep', '3'])
     assert_images(docker_client, id1, id2)
 
 
-def test_no_images_removed_exactly(docker_client, image_factory):
+def test_no_images_removed_exactly(docker_client, image_factory, docker_rotate):
 
     assert_images(docker_client)
     id1 = image_factory.add('image_1', 'latest')
     id2 = image_factory.add('image_2', 'latest')
 
-    main(['images', '--keep', '2'])
+    docker_rotate(['images', '--keep', '2'])
     assert_images(docker_client, id1, id2)
 
 
-def test_remove_image(docker_client, image_factory):
+def test_remove_image(docker_client, image_factory, docker_rotate):
     assert_images(docker_client)
     id1 = image_factory.add('image_1', 'latest')
     id2 = image_factory.add('image_2', 'latest')
@@ -30,14 +29,14 @@ def test_remove_image(docker_client, image_factory):
     id4 = image_factory.add('image_4', 'latest')
     assert_images(docker_client, id1, id2, id3, id4)
 
-    main(['images', '--keep', '2'])
+    docker_rotate(['images', '--keep', '2'])
     assert_images(docker_client, id3, id4)
 
 
 OTHER_TEST_IMAGE_NAME = 'locationlabs/zzzdockergentest_otherimage'
 
 
-def test_remove_only_matching(docker_client, image_factory):
+def test_remove_only_matching(docker_client, image_factory, docker_rotate):
 
     assert_images(docker_client)
     id1 = image_factory.add('image_1', 'latest')
@@ -56,12 +55,12 @@ def test_remove_only_matching(docker_client, image_factory):
         print " - id {}, tag0 {}, created {}".format(
             image["Id"], image["RepoTags"][0], image["Created"])
 
-    main(['images', '--keep', '2', '--name', OTHER_TEST_IMAGE_NAME])
+    docker_rotate(['images', '--keep', '2', '--name', OTHER_TEST_IMAGE_NAME])
 
     assert_images(docker_client, id1, id2, id3, id4, oid3, oid4)
 
 
-def test_skip_removing_old_latest(docker_client, image_factory):
+def test_skip_removing_old_latest(docker_client, image_factory, docker_rotate):
 
     assert_images(docker_client)
     id1 = image_factory.add('image_1', 'latest')
@@ -77,13 +76,13 @@ def test_skip_removing_old_latest(docker_client, image_factory):
             image["Id"], image["RepoTags"][0], image["Created"])
 
     # clean up images, but leave latest
-    main(['images', '--keep', '2', '--name', image_factory.name, '--tag', '~latest'])
+    docker_rotate(['images', '--keep', '2', '--name', image_factory.name, '--tag', '~latest'])
 
     # check that we have the most recent two plus "latest"
     assert_images(docker_client, id1, id3, id4)
 
 
-def test_skip_removing_new_latest(docker_client, image_factory):
+def test_skip_removing_new_latest(docker_client, image_factory, docker_rotate):
 
     assert_images(docker_client)
     id1 = image_factory.add('image_1')
@@ -93,13 +92,13 @@ def test_skip_removing_new_latest(docker_client, image_factory):
     assert_images(docker_client, id1, id2, id3, id4)
 
     # clean up images, but leave latest
-    main(['images', '--keep', '2', '--name', image_factory.name, '--tag', '~latest'])
+    docker_rotate(['images', '--keep', '2', '--name', image_factory.name, '--tag', '~latest'])
 
     # check that we have just the most recent two
     assert_images(docker_client, id3, id4)
 
 
-def test_skip_removing_in_use(docker_client, container_factory):
+def test_skip_removing_in_use(docker_client, container_factory, docker_rotate):
     # container factory creates an image when created.
     id1 = container_factory.image_id
 
@@ -111,13 +110,13 @@ def test_skip_removing_in_use(docker_client, container_factory):
     id3 = container_factory.image_factory.add("yet_another_image", "latest")
 
     # clean up images
-    main(['images', '--keep', '1'])
+    docker_rotate(['images', '--keep', '1'])
 
     # original should still be there, and most recent, but middle image should be gone.
     assert_images(docker_client, id1, id3)
 
 
-def test_remove_matching_image(docker_client, image_factory):
+def test_remove_matching_image(docker_client, image_factory, docker_rotate):
 
     assert_images(docker_client)
     tag = 'image_1'
@@ -133,7 +132,7 @@ def test_remove_matching_image(docker_client, image_factory):
 
         assert_images(docker_client, id1, id2)
 
-        main(['images', '--keep', '0', '--name', image_factory.name])
+        docker_rotate(['images', '--keep', '0', '--name', image_factory.name])
 
         assert_images(docker_client, id2)
 
@@ -141,7 +140,7 @@ def test_remove_matching_image(docker_client, image_factory):
         other_image_factory.cleanup()
 
 
-def test_remove_matching_image_extra_tag(docker_client, image_factory):
+def test_remove_matching_image_extra_tag(docker_client, image_factory, docker_rotate):
 
     assert_images(docker_client)
     tag = 'image_1'
@@ -158,7 +157,7 @@ def test_remove_matching_image_extra_tag(docker_client, image_factory):
 
         assert_images(docker_client, id1, id2)
 
-        main(['images', '--keep', '0', '--name', image_factory.name])
+        docker_rotate(['images', '--keep', '0', '--name', image_factory.name])
 
         assert_images(docker_client, id2)
 

--- a/integration_test/test_untagged.py
+++ b/integration_test/test_untagged.py
@@ -1,28 +1,28 @@
-from dockerrotate.main import main
 from imagetools import assert_images
 
-def test_untagged_null_case(docker_client):
+
+def test_untagged_null_case(docker_client, docker_rotate):
     # verify we have no images to start with
     assert_images(docker_client)
 
     # Run main and verify it doesn't fail
-    main(['untagged-images'])
+    docker_rotate(['untagged-images'])
 
 
-def test_untagged(docker_client, image_factory):
+def test_untagged(docker_client, image_factory, docker_rotate):
     # add an image, then a second image with the same tag
     # the first image will remain, but untagged.
     id1 = image_factory.add('some_tag')
     id2 = image_factory.add('some_tag')
     assert_images(docker_client, id1, id2)
 
-    main(['untagged-images'])
+    docker_rotate(['untagged-images'])
 
     # verify that the untagged image was removed
     assert_images(docker_client, id2)
 
 
-def test_image_in_use(docker_client, container_factory):
+def test_image_in_use(docker_client, container_factory, docker_rotate):
 
     # container factory creates an image when created.
     id1 = container_factory.image_id
@@ -40,7 +40,7 @@ def test_image_in_use(docker_client, container_factory):
     for container in docker_client.containers(all=True):
         print json.dumps(container, indent=3)
 
-    main(['untagged-images'])
+    docker_rotate(['untagged-images'])
 
     # verify that the untagged image was not removed
     assert_images(docker_client, id1, id2)

--- a/integration_test/test_untagged.py
+++ b/integration_test/test_untagged.py
@@ -28,7 +28,7 @@ def test_image_in_use(docker_client, container_factory):
     id1 = container_factory.image_id
 
     # create a container that uses that image
-    cid1 = container_factory.make_created()
+    container_factory.make_created()
 
     # create a new image with the same factory and the same tags, to make the old image untagged
     id2 = container_factory.image_factory.add(container_factory.IMAGE_TAG, "latest")
@@ -44,8 +44,3 @@ def test_image_in_use(docker_client, container_factory):
 
     # verify that the untagged image was not removed
     assert_images(docker_client, id1, id2)
-
-
-
-
-


### PR DESCRIPTION
The code depends on `ImageId` in the "list containers" result and on
`State.Status` in the "inspect a container" result.

API v1.21 added these to those respective results.

Wrap the `args.client.containers(all=True)` call with code to fill in
`ImageId` by inspecting each returned container.

Wrap the `args.client.inspect_container` call with code to fill in
`Status.State` based on the other fields available.